### PR TITLE
Fix spelling error in footer comment

### DIFF
--- a/footer.php
+++ b/footer.php
@@ -3,7 +3,7 @@
  * Third party plugins that hijack the theme will call wp_footer() to get the footer template.
  * We use this to end our output buffer (started in header.php) and render into the view/page-plugin.twig template.
  *
- * If you're not using a plugin that requries this behavior (ones that do include Events Calendar Pro and
+ * If you're not using a plugin that requires this behavior (ones that do include Events Calendar Pro and
  * WooCommerce) you can delete this file and header.php
  *
  * @package  WordPress


### PR DESCRIPTION
## Summary
- fix typo "requries" -> "requires" in footer comment

## Testing
- `composer test` *(fails: Failed opening required 'wp-settings.php')*

------
https://chatgpt.com/codex/tasks/task_e_6894f37fb2b88331a6747e4213f7cd07