### PR TITLE
Fix Swiper initialization after AJAX filtering

### DIFF
--- a/assets/js/scripts/filter.js
+++ b/assets/js/scripts/filter.js
@@ -1,4 +1,5 @@
 import noUiSlider from 'nouislider';
+import { swiperInit } from '../plugins/swiperInit.js';
 
 export function filter() {
 	const filterForm = document.querySelector('[data-filter-form]');
@@ -222,9 +223,10 @@ export function filter() {
 					animateItems();
 				}
 	
-				initSliders();
-				initOptionToggles();
-				initFilterButtons();
+                                initSliders();
+                                initOptionToggles();
+                                initFilterButtons();
+                                swiperInit();
 	
 				const el = document.createElement('div');
 				el.innerHTML = html;


### PR DESCRIPTION
## Summary
- reinitialize Swiper after loading filtered results

## Testing
- `npm test` *(fails: Missing script "test")*
- `composer test` *(fails: Error in bootstrap script)*

------
https://chatgpt.com/codex/tasks/task_e_68950d3f9e308331b8222288af96efec