### PR TITLE
Allow custom posts per page in archive load more

### DIFF
--- a/archive.php
+++ b/archive.php
@@ -13,9 +13,12 @@
 
 $context = Timber::context(); // Basiscontext vanuit Timber, bevat globale data (site, user, etc.)
 
-$post_type = get_post_type(); 
-$context['post_type'] = $post_type; // Nodig voor AJAX (JS moet weten welk post_type gefilterd wordt)
-$context['filters'] = [];
+$posts_per_page = 12; // Aantal resultaten per pagina
+
+$post_type = get_post_type();
+$context['post_type']     = $post_type; // Nodig voor AJAX (JS moet weten welk post_type gefilterd wordt)
+$context['posts_per_page'] = $posts_per_page; // Doorgeven aan Twig & AJAX
+$context['filters']       = [];
 
 /**
  * 🧩 Filters
@@ -53,7 +56,7 @@ $context['filters'] = [];
  */
 $query_args = [
   'post_type'      => $post_type,
-  'posts_per_page' => 12,                     // Resultaten per pagina
+  'posts_per_page' => $posts_per_page,                     // Resultaten per pagina
   'paged'          => get_query_var('paged') ?: 1, // Huidige paginanummer (voor paginatie)
 ];
 

--- a/components/library/filter/FilterAjax.php
+++ b/components/library/filter/FilterAjax.php
@@ -9,8 +9,9 @@ class Components_FilterAjax {
 			wp_die();
 		}
 	
-		$post_type = sanitize_text_field($filters['post_type'] ?? 'post');
-		$paged     = (int)($filters['paged'] ?? 1);
+                $post_type      = sanitize_text_field($filters['post_type'] ?? 'post');
+                $paged          = (int)($filters['paged'] ?? 1);
+                $posts_per_page = max(1, (int)($filters['posts_per_page'] ?? 12));
 	
 		// 🔍 Meta filters
 		$meta_query = [];
@@ -93,15 +94,15 @@ class Components_FilterAjax {
 		}
 		
 		// 🔍 WP_Query args
-		$args = [
-			'post_type'      => $post_type,
-			'post_status'    => 'publish',
-			'posts_per_page' => 12,
-			'paged'          => $paged,
-			'orderby'        => $orderby,
-			'order'          => $order,
-			'meta_query'     => $meta_query,
-		];
+                $args = [
+                        'post_type'      => $post_type,
+                        'post_status'    => 'publish',
+                        'posts_per_page' => $posts_per_page,
+                        'paged'          => $paged,
+                        'orderby'        => $orderby,
+                        'order'          => $order,
+                        'meta_query'     => $meta_query,
+                ];
 		
 		if (!empty($filters['s'])) {
 			$args['s'] = sanitize_text_field($filters['s']);

--- a/views/archive-filter.twig
+++ b/views/archive-filter.twig
@@ -7,6 +7,7 @@
 <section class="bg-greylight">
 	<div class="container">
 		<form data-filter-form data-post-type="{{ post_type }}">
+				<input type="hidden" name="posts_per_page" value="{{ posts_per_page }}">
 			<div class="row mb-5">
 				<div class="col-md-4 d-flex align-items-center">
 					<a href="{{ site.link }}">Home </a> <span> / </span> {{ post_type|capitalize }}

--- a/views/archive-locaties.twig
+++ b/views/archive-locaties.twig
@@ -7,6 +7,7 @@
 <section class="bg-greylight">
 	<div class="container">
 		<form data-filter-form data-post-type="{{ post_type }}">
+				<input type="hidden" name="posts_per_page" value="{{ posts_per_page }}">
 			<div class="row mb-5">
 				<div class="col-md-4 d-flex align-items-center">
 					<a href="{{ site.link }}">Home </a> <span> / </span> {{ post_type|capitalize }}

--- a/views/archive.twig
+++ b/views/archive.twig
@@ -7,6 +7,7 @@
 <section class="bg-greylight">
 	<div class="container">
 		<form data-filter-form data-post-type="{{ post_type }}">
+				<input type="hidden" name="posts_per_page" value="{{ posts_per_page }}">
 			<div class="row mb-5">
 				<div class="col-md-4 d-flex align-items-center">
 					<a href="{{ site.link }}">Home </a> / {{ post_type|capitalize }}


### PR DESCRIPTION
## Summary
- Centralize archive posts per page setting and expose to Twig
- Pass posts-per-page value through AJAX handler
- Include hidden posts-per-page field in archive templates

## Testing
- `composer test` *(fails: Failed opening required wp-settings.php)*

------
https://chatgpt.com/codex/tasks/task_e_68950dbfc9a083318066358076a036a7