### PR TITLE
Move component scripts into component library

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -4,11 +4,15 @@ window.bootstrap = bootstrap;
 // Init plugins
 import { lightgalleryInit } from './plugins/lightgalleryInit.js';
 import { matchheightInit } from './plugins/matchheightInit.js';
-import { swiperInit } from './plugins/swiperInit.js';
 
-// Scripts
+// Component scripts
+// Deze imports wijzen direct naar de componenten-map zodat alle componentcode
+// gecentraliseerd blijft. Vervang de map later eenvoudig zonder overige assets aan te passen.
+import { swiperInit } from '../../components/library/swiper/swiperInit.js';
+import { filter } from '../../components/library/filter/filter.js';
+
+// Theme scripts
 import { cta } from './scripts/cta.js';
-import { filter } from './scripts/filter.js';
 import { footer } from './scripts/footer.js';
 import { header } from './scripts/header.js';
 import { mobileMenu } from './scripts/mobileMenu.js';

--- a/components/library/filter/filter.js
+++ b/components/library/filter/filter.js
@@ -1,7 +1,8 @@
+// Component script: Filter
 import noUiSlider from 'nouislider';
 import flatpickr from 'flatpickr/dist/flatpickr.js';
 import rangePlugin from 'flatpickr/dist/plugins/rangePlugin.js';
-import { swiperInit } from '../plugins/swiperInit.js';
+import { swiperInit } from '../swiper/swiperInit.js';
 
 export function filter() {
 	const filterForm = document.querySelector('[data-filter-form]');

--- a/components/library/swiper/swiperInit.js
+++ b/components/library/swiper/swiperInit.js
@@ -1,4 +1,4 @@
-// Updated JavaScript for Swiper Component
+// Component script: Swiper initialisatie
 import Swiper from 'swiper/bundle';
 
 export function swiperInit() {

--- a/config.codekit3
+++ b/config.codekit3
@@ -1180,13 +1180,13 @@
       "sC" : 3,
       "tS" : 0
     },
-    "\/assets\/js\/plugins\/swiperInit.js" : {
+    "\/components\/library\/swiper\/swiperInit.js" : {
       "bF" : 0,
       "ft" : 64,
       "ma" : 0,
       "mi" : 1,
       "oA" : 1,
-      "oAP" : "\/assets\/js\/plugins\/swiperInit-min.js",
+      "oAP" : "\/components\/library\/swiper\/swiperInit-min.js",
       "oF" : 0,
       "sC" : 3,
       "tS" : 0

--- a/functions.php
+++ b/functions.php
@@ -16,6 +16,8 @@ require_once __DIR__ . '/src/ThemeSpecific.php';
 require_once __DIR__ . '/src/WPAdmin.php';
 
 
+// Registreer en laad alle componenten vanuit de componenten-map.
+// Hierdoor kan de gehele map later eenvoudig worden vervangen.
 require_once __DIR__ . '/components/Components.php';
 
 Timber\Timber::init();


### PR DESCRIPTION
## Summary
- relocate Filter and Swiper JavaScript into their respective component folders
- import component scripts directly from the component library and document the setup
- clarify component loading in functions.php

## Testing
- `composer test` *(fails: Failed opening required '/workspace/skeletor/vendor/automattic/wordbless/src/../../../../wordpress//wp-settings.php')*

------
https://chatgpt.com/codex/tasks/task_e_689b0151a13c83319d6872d621d92ea5