### PR TITLE
Fix date filter reset and dynamic bounds

### DIFF
--- a/views/partials/list.twig
+++ b/views/partials/list.twig
@@ -19,3 +19,6 @@
 {% if option_counts is defined %}
 <div data-option-counts="{{ option_counts|json_encode }}" hidden></div>
 {% endif %}
+{% if date_bounds is defined %}
+<div data-date-bounds="{{ date_bounds|json_encode }}" hidden></div>
+{% endif %}


### PR DESCRIPTION
## Summary
- ensure date pickers trigger filtering and reset to defaults
- compute and apply dynamic date bounds based on current results

## Testing
- `composer test` *(fails: Failed opening required '/workspace/skeletor/vendor/automattic/wordbless/src/../../../../wordpress//wp-settings.php')*

------
https://chatgpt.com/codex/tasks/task_e_689b9047fe20833186109392a2f01a90