### PR TITLE
Fix date range start filter and reset formatting

### DIFF
--- a/assets/js/scripts/filter.js
+++ b/assets/js/scripts/filter.js
@@ -182,13 +182,31 @@ export function filter() {
                                dateFormat: 'Y-m-d',
                                altFormat: format,
                                plugins: endEl ? [new rangePlugin({ input: endEl })] : [],
+                               onReady: (selectedDates, _dateStr, instance) => {
+                                       if (selectedDates[0]) {
+                                               startEl.value = instance.formatDate(selectedDates[0], 'Y-m-d');
+                                       }
+                                       if (endEl && selectedDates[1]) {
+                                               endEl.value = instance.formatDate(selectedDates[1], 'Y-m-d');
+                                       }
+                               },
+                               onValueUpdate: (selectedDates, _dateStr, instance) => {
+                                       startEl.value = selectedDates[0]
+                                               ? instance.formatDate(selectedDates[0], 'Y-m-d')
+                                               : '';
+                                       if (endEl) {
+                                               endEl.value = selectedDates[1]
+                                                       ? instance.formatDate(selectedDates[1], 'Y-m-d')
+                                                       : '';
+                                       }
+                               },
                                onChange: () => {
                                        startEl.dispatchEvent(new Event('change', { bubbles: true }));
                                        if (endEl) endEl.dispatchEvent(new Event('change', { bubbles: true }));
                                }
                        });
                });
-        };
+       };
 
         const initSliders = () => {
                 document.querySelectorAll('[data-slider]').forEach(sliderEl => {

--- a/assets/js/scripts/filter.js
+++ b/assets/js/scripts/filter.js
@@ -164,7 +164,12 @@ export function filter() {
                document.querySelectorAll('[data-date-picker]').forEach(el => {
                        if (el._flatpickr) return;
                        const format = el.dataset.dateFormat || 'd-m-Y';
-                       flatpickr(el, { altInput: true, dateFormat: 'Y-m-d', altFormat: format });
+                       flatpickr(el, {
+                               altInput: true,
+                               dateFormat: 'Y-m-d',
+                               altFormat: format,
+                               onChange: () => el.dispatchEvent(new Event('change', { bubbles: true }))
+                       });
                });
 
                document.querySelectorAll('[data-date-range-start]').forEach(startEl => {
@@ -176,11 +181,12 @@ export function filter() {
                                altInput: true,
                                dateFormat: 'Y-m-d',
                                altFormat: format,
-                               plugins: endEl ? [new rangePlugin({ input: endEl })] : []
+                               plugins: endEl ? [new rangePlugin({ input: endEl })] : [],
+                               onChange: () => {
+                                       startEl.dispatchEvent(new Event('change', { bubbles: true }));
+                                       if (endEl) endEl.dispatchEvent(new Event('change', { bubbles: true }));
+                               }
                        });
-                       if (endEl && !endEl._flatpickr) {
-                               flatpickr(endEl, { altInput: true, dateFormat: 'Y-m-d', altFormat: format });
-                       }
                });
         };
 
@@ -359,7 +365,22 @@ export function filter() {
                         });
 
                         // Reset date pickers naar oorspronkelijke waardes
-                        filterForm.querySelectorAll('[data-date-picker], [data-date-range-start], [data-date-range-end]').forEach(el => {
+                        filterForm.querySelectorAll('[data-date-range-start]').forEach(startEl => {
+                                const key = startEl.dataset.dateRangeStart;
+                                const endEl = filterForm.querySelector(`[data-date-range-end="${key}"]`);
+                                if (startEl._flatpickr) {
+                                        const dates = [];
+                                        if (startEl.value) dates.push(startEl.value);
+                                        if (endEl && endEl.value) dates.push(endEl.value);
+                                        if (dates.length) {
+                                                startEl._flatpickr.setDate(dates, false);
+                                        } else {
+                                                startEl._flatpickr.clear();
+                                        }
+                                }
+                        });
+                        filterForm.querySelectorAll('[data-date-picker]').forEach(el => {
+                                if (el.dataset.dateRangeStart || el.dataset.dateRangeEnd) return;
                                 if (el._flatpickr) {
                                         el._flatpickr.setDate(el.value || null, false);
                                 }

--- a/assets/js/scripts/filter.js
+++ b/assets/js/scripts/filter.js
@@ -165,9 +165,7 @@ export function filter() {
                        if (el._flatpickr) return;
                        const format = el.dataset.dateFormat || 'd-m-Y';
                        flatpickr(el, {
-                               altInput: true,
-                               dateFormat: 'Y-m-d',
-                               altFormat: format,
+                               dateFormat: format,
                                onChange: () => el.dispatchEvent(new Event('change', { bubbles: true }))
                        });
                });
@@ -178,28 +176,8 @@ export function filter() {
                        const endEl = document.querySelector(`[data-date-range-end="${key}"]`);
                        const format = startEl.dataset.dateFormat || 'd-m-Y';
                        flatpickr(startEl, {
-                               altInput: true,
-                               dateFormat: 'Y-m-d',
-                               altFormat: format,
+                               dateFormat: format,
                                plugins: endEl ? [new rangePlugin({ input: endEl })] : [],
-                               onReady: (selectedDates, _dateStr, instance) => {
-                                       if (selectedDates[0]) {
-                                               startEl.value = instance.formatDate(selectedDates[0], 'Y-m-d');
-                                       }
-                                       if (endEl && selectedDates[1]) {
-                                               endEl.value = instance.formatDate(selectedDates[1], 'Y-m-d');
-                                       }
-                               },
-                               onValueUpdate: (selectedDates, _dateStr, instance) => {
-                                       startEl.value = selectedDates[0]
-                                               ? instance.formatDate(selectedDates[0], 'Y-m-d')
-                                               : '';
-                                       if (endEl) {
-                                               endEl.value = selectedDates[1]
-                                                       ? instance.formatDate(selectedDates[1], 'Y-m-d')
-                                                       : '';
-                                       }
-                               },
                                onChange: () => {
                                        startEl.dispatchEvent(new Event('change', { bubbles: true }));
                                        if (endEl) endEl.dispatchEvent(new Event('change', { bubbles: true }));

--- a/components/library/filter/FilterAjax.php
+++ b/components/library/filter/FilterAjax.php
@@ -9,8 +9,16 @@
  * - publicatiedatum filteren met de special key `post_date`
  */
 class Components_FilterAjax {
-	public static function handle() {
-		$filters = $_POST;
+       private static function normalize_date($date) {
+               if (empty($date)) return '';
+               $d = \DateTime::createFromFormat('Y-m-d', $date);
+               if (!$d) {
+                       $d = \DateTime::createFromFormat('d-m-Y', $date);
+               }
+               return $d ? $d->format('Y-m-d') : '';
+       }
+        public static function handle() {
+                $filters = $_POST;
 	
 		if (!is_array($filters)) {
 			echo '❌ Ongeldige filterdata ontvangen';
@@ -58,9 +66,9 @@ class Components_FilterAjax {
                                 }
                         }
                         if (strpos($key, 'from_') === 0) {
-                                $base = substr($key, 5);
-                                $from = $_POST['from_' . $base] ?? '';
-                                $to   = $_POST['to_' . $base] ?? '';
+                               $base = substr($key, 5);
+                               $from = self::normalize_date($_POST['from_' . $base] ?? '');
+                               $to   = self::normalize_date($_POST['to_' . $base] ?? '');
 
                                 $from_filled = $from !== '';
                                 $to_filled   = $to !== '';


### PR DESCRIPTION
## Summary
- dispatch change events for both start and end fields so range filters include the starting date
- refine reset logic to clear or restore date ranges with proper `dd-mm-yyyy` display

## Testing
- `npm test` *(fails: Missing script "test")*
- `vendor/bin/phpunit` *(fails: Failed opening required '/workspace/skeletor/vendor/automattic/wordbless/src/../../../../wordpress//wp-settings.php')*


------
https://chatgpt.com/codex/tasks/task_e_689ba6fbf5a48331adb7e4dd3d93c4b2