### PR TITLE
doc: update filter component documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,15 +55,11 @@ Definieer filters in PHP en render ze in Twig:
 }) }}
 {{ sort_select(filters.sort) }}
 ```
-<<<<<<< HEAD
-- Ondersteunt `select`, `checkbox`, `radio`, `buttons` en `range`.
-- Data-opties per filter: `name`, `label`, `type`, `source`, `options`, `value`, `sort_options`, `hide_empty_options`.
-- Presentatie-opties: `limit_options`, `option_list_expand_label`, `option_list_collapse_label`, `placeholder`, `layout`, `show_field_label`, `show_option_counts`.
-- `sort_select` accepteert `id`, `name`, `label`, `value` en voegt een standaard sorteermenu toe.
-=======
 - Ondersteunt `select`, `checkbox`, `radio`, `buttons`, `range`, `date` en `date_range`.
-- `sort_select` voegt een standaard sorteermenu toe.
->>>>>>> add-date-filter-component
+- Data-opties per filter: `name`, `label`, `type`, `source`, `options`, `value`, `sort_options`, `hide_empty_options`.
+- Presentatie-opties: `limit_options`, `option_list_expand_label`, `option_list_collapse_label`, `placeholder`, `layout`, `show_field_label`, `show_option_counts`, `date_format`.
+- `sort_select` accepteert `id`, `name`, `label`, `value` en voegt een standaard sorteermenu toe.
+- Voor type `buttons` zijn extra opties beschikbaar: `button_class`, `all_label`, `show_all_button`.
 
 Voor een datumfilter kan gefilterd worden op publicatiedatum (`source: 'post_date'`) of op een ACF-datumveld (`source: 'acf'`).
 

--- a/components/library/filter/Filter.php
+++ b/components/library/filter/Filter.php
@@ -10,10 +10,11 @@
  * $context['filters']['uren'] = [
  *   'name'       => 'uren',                   // input name, ook gebruikt in GET
  *   'label'      => 'Uren',                   // veldlabel
- *   'type'       => 'checkbox',               // 'select', 'checkbox', 'radio', 'range', 'date', 'date_range'
+ *   'type'       => 'checkbox',               // 'select', 'checkbox', 'radio', 'buttons', 'range', 'date', 'date_range'
  *   'source'     => 'acf',                    // 'acf', 'taxonomy' of 'post_date'
  *   'value'      => $_GET['uren'] ?? null,    // huidige waarde (optioneel)
  *   'options'    => Components_Filter::get_options_from_meta('uren'), // array met key => value
+ *   'date_format'=> 'd-m-Y',                 // formaat voor datumvelden (optioneel)
  *
  *   // Alleen data-logica in PHP (géén presentatie):
  *   'sort_options'       => 'asc',      // 'asc', 'desc', 'none'

--- a/components/library/filter/filter.twig
+++ b/components/library/filter/filter.twig
@@ -11,13 +11,18 @@ Voorbeeld:
   placeholder: 'Maak een keuze',
   layout: 'horizontal',
   show_field_label: true,
-  show_option_counts: true
+  show_option_counts: true,
+  button_class: 'btn-outline-primary',
+  all_label: 'Alles',
+  show_all_button: true,
+  date_format: 'd-m-Y'
 }) }}
 
 Types: 'select', 'checkbox', 'radio', 'buttons', 'range', 'date' en 'date_range'.
 
-Datumfilters vullen automatisch de oudste en nieuwste beschikbare datum in wanneer
-er geen waarde is opgegeven.
+Datumfilters vullen automatisch de oudste en nieuwste beschikbare datum in wanneer er geen waarde is opgegeven.
+
+Beschikbare data-opties: `name`, `label`, `type`, `source`, `options`, `value`, `sort_options`, `hide_empty_options`.
 
 Beschikbare presentatie-opties:
 - limit_options: int – aantal direct zichtbare opties vóór "Toon meer"
@@ -27,6 +32,10 @@ Beschikbare presentatie-opties:
 - layout: 'vertical' (default) of 'horizontal'
 - show_field_label: true/false (default: true)
 - show_option_counts: true/false – toon aantal resultaten per optie
+- date_format: string – formaat voor datumvelden
+- button_class: string – knopstijl (alleen voor type 'buttons')
+- all_label: string – label voor 'alles'-knop (alleen voor type 'buttons')
+- show_all_button: true/false – toon 'alles'-knop (alleen voor type 'buttons')
 #}
 
 {% set name = name ?? acf_field ?? '' %}

--- a/components/library/filter/sortselect.twig
+++ b/components/library/filter/sortselect.twig
@@ -5,17 +5,29 @@ Gebruik dit component om een gestandaardiseerde sorteer-select dropdown te tonen
 
 Voorbeeld:
   {{ sort_select(filters.sort, {
-	options: {
-	  'relevance': 'Relevantie',
-	  'date_desc': 'Nieuwste eerst',
-	  'date_asc': 'Oudste eerst',
-	  'title_asc': 'Titel A-Z',
-	  'title_desc': 'Titel Z-A'
-	},
-	show_label: true,
-	label: 'Sorteer op:',
-	layout: 'vertical'  // of 'horizontal'
+        id: 'sort',
+        name: 'sort',
+        value: 'relevance',
+        options: {
+          'relevance': 'Relevantie',
+          'date_desc': 'Nieuwste eerst',
+          'date_asc': 'Oudste eerst',
+          'title_asc': 'Titel A-Z',
+          'title_desc': 'Titel Z-A'
+        },
+        show_label: true,
+        label: 'Sorteer op:',
+        layout: 'vertical'  // of 'horizontal'
   }) }}
+#
+Opties:
+- id: string – `id` attribuut (default 'sort')
+- name: string – inputnaam (default 'sort')
+- label: string – veldlabel (default 'Sorteer op:')
+- value: string – huidige waarde (default 'relevance')
+- options: key => label array
+- show_label: true/false (default: true)
+- layout: 'vertical' (default) of 'horizontal'
 #}
 
 {% set id = id|default('sort') %}


### PR DESCRIPTION
## Summary
- document all filter component types and configuration options

## Testing
- `composer test` *(fails: Failed opening required '/workspace/skeletor/vendor/automattic/wordbless/.../wp-settings.php')*


------
https://chatgpt.com/codex/tasks/task_e_689cd73a5bdc8331af2e2dcba3326397