### PR TITLE
Add persistent topbar with service menu

### DIFF
--- a/assets/scss/layout/_header.scss
+++ b/assets/scss/layout/_header.scss
@@ -1,20 +1,22 @@
 $header-height: 60px;
 $header-height-lg: 110px;
+$topbar-height: 30px;
+$topbar-height-lg: 40px;
 
 body {
-	padding-top: $header-height;
+        padding-top: $topbar-height + $header-height;
 
-	&.header-transparent {
-		padding-top: 0;
+        &.header-transparent {
+                padding-top: $topbar-height;
 
-		.header {
-			background: transparent;
-		}
+                .header {
+                        background: transparent;
+                }
 
-		main > section:first-child > *:first-child {
-			padding-top: $header-height;
-		}
-	}
+                main > section:first-child > *:first-child {
+                        padding-top: $topbar-height + $header-height;
+                }
+        }
 
 	&:not(.header-transparent) {
 		.header {
@@ -39,12 +41,23 @@ body {
 		}
 	}
 
-	.header {
-		position: fixed;
-		top: 0;
-		left: 0;
-		width: 100%;
-		height: $header-height;
+        .topbar {
+                position: fixed;
+                top: 0;
+                left: 0;
+                width: 100%;
+                height: $topbar-height;
+                background: $light;
+                z-index: 1100;
+                font-size: .875rem;
+        }
+
+        .header {
+                position: fixed;
+                top: $topbar-height;
+                left: 0;
+                width: 100%;
+                height: $header-height;
 		background: $light;
 		z-index: 1000;
 		transition: opacity 0.3s $ease, transform 0.3s $ease, background 0.3s $ease;
@@ -82,10 +95,10 @@ body {
 			}
 		}
 
-		&.hidden {
-			transform: translateY(-100%);
-			opacity: 0;
-		}
+                &.hidden {
+                        transform: translateY(calc(-100% - #{$topbar-height}));
+                        opacity: 0;
+                }
 
 		&.visible {
 			transform: translateY(0);
@@ -119,25 +132,34 @@ body {
 }
 
 @include media-breakpoint-up(lg) {
-	body {
-		padding-top: $header-height-lg;
+        body {
+                padding-top: $topbar-height-lg + $header-height-lg;
 
-		&.header-transparent {
-			padding-top: 0;
+                &.header-transparent {
+                        padding-top: $topbar-height-lg;
 
-			main > section:first-child > *:first-child {
-				padding-top: $header-height-lg;
-			}
-		}
+                        main > section:first-child > *:first-child {
+                                padding-top: $topbar-height-lg + $header-height-lg;
+                        }
+                }
 
-		.header {
-			height: $header-height-lg;
+                .topbar {
+                        height: $topbar-height-lg;
+                }
 
-			.header-brand {
-				img {
-					height: 30px;
-				}
-			}
-		}
-	}
+                .header {
+                        top: $topbar-height-lg;
+                        height: $header-height-lg;
+
+                        &.hidden {
+                                transform: translateY(calc(-100% - #{$topbar-height-lg}));
+                        }
+
+                        .header-brand {
+                                img {
+                                        height: 30px;
+                                }
+                        }
+                }
+        }
 }

--- a/dist/main-min.css
+++ b/dist/main-min.css
@@ -32228,5 +32228,5 @@ span.flatpickr-weekday {
     transform: translate3d(0, 0, 0);
   }
 }
-
+body{padding-top:90px}body.header-transparent{padding-top:30px}body.header-transparent main>section:first-child>*:first-child{padding-top:90px}body .topbar{position:fixed;top:0;left:0;width:100%;height:30px;background:#FFFFFF;z-index:1100;font-size:.875rem}body .header{top:30px}body .header.hidden{transform:translateY(calc(-100% - 30px))}@media (min-width:992px){body{padding-top:150px}body.header-transparent{padding-top:40px}body.header-transparent main>section:first-child>*:first-child{padding-top:150px}body .topbar{height:40px}body .header{top:40px}body .header.hidden{transform:translateY(calc(-100% - 40px))}}
 /*# sourceMappingURL=main-min.css.map */

--- a/src/Menu.php
+++ b/src/Menu.php
@@ -18,9 +18,10 @@ class Menu extends Site {
 	/**
 	 * Registreer navigatiemenu's
 	 */
-	public function register_nav_menus() {
-		register_nav_menu('headermenu', __('Header menu'));
-		register_nav_menu('footermenu', __('Footer menu'));
-		register_nav_menu('mobielmenu', __('Mobiel menu'));
-	}
+        public function register_nav_menus() {
+                register_nav_menu('headermenu', __('Header menu'));
+                register_nav_menu('servicemenu', __('Service menu'));
+                register_nav_menu('footermenu', __('Footer menu'));
+                register_nav_menu('mobielmenu', __('Mobiel menu'));
+        }
 }

--- a/src/StarterSite.php
+++ b/src/StarterSite.php
@@ -39,9 +39,10 @@ class StarterSite extends Site {
 		}
 
 		// Haal menu's op
-		$context['headermenu'] = \Timber\Timber::get_menu('headermenu');
-		$context['footermenu'] = \Timber\Timber::get_menu('footermenu');
-		$context['mobielmenu'] = \Timber\Timber::get_menu('mobielmenu');
+                $context['headermenu'] = \Timber\Timber::get_menu('headermenu');
+                $context['servicemenu'] = \Timber\Timber::get_menu('servicemenu');
+                $context['footermenu'] = \Timber\Timber::get_menu('footermenu');
+                $context['mobielmenu'] = \Timber\Timber::get_menu('mobielmenu');
 		
 		// Voeg optiespagina velden toe
 		$context['options'] = get_fields('options');

--- a/views/header.twig
+++ b/views/header.twig
@@ -1,35 +1,50 @@
+<div class="topbar">
+        <div class="container">
+                <div class="row w-100 g-2">
+                        <div class="col small d-flex align-items-center">
+                                {{ site.description }}
+                        </div>
+                        {% if servicemenu %}
+                                <div class="col-auto d-flex align-items-center">
+                                        {% include "partials/menu.twig" with {'items': servicemenu.get_items} %}
+                                </div>
+                        {% endif %}
+                </div>
+        </div>
+</div>
+
 <header class="header d-flex align-items-center">
-	<div class="container">
-		<div class="row w-100 g-2">
-			<div class="col d-flex align-items-center">
-				<a class="header-brand" href="{{ site.url }}" rel="home">
-					<span class="d-none">{{ site.name }}</span>
-					<img height="42" src="{{ theme.link }}/assets/images/emonks-color.svg" alt="{{ site.title }}">
-				</a>
-			</div>
-			{% if headermenu %}
-				<div class="col-auto d-none d-lg-flex align-items-center">
-					{% include "partials/menu-dropdown.twig" with {'items': headermenu.get_items} %}
-				</div>
-			{% endif %}
-		</div>
-	</div>
+        <div class="container">
+                <div class="row w-100 g-2">
+                        <div class="col d-flex align-items-center">
+                                <a class="header-brand" href="{{ site.url }}" rel="home">
+                                        <span class="d-none">{{ site.name }}</span>
+                                        <img height="42" src="{{ theme.link }}/assets/images/emonks-color.svg" alt="{{ site.title }}">
+                                </a>
+                        </div>
+                        {% if headermenu %}
+                                <div class="col-auto d-none d-lg-flex align-items-center">
+                                        {% include "partials/menu-dropdown.twig" with {'items': headermenu.get_items} %}
+                                </div>
+                        {% endif %}
+                </div>
+        </div>
 </header>
 
 {% if headermenu %}
-	<!-- Hamburger menu button -->
-	<button id="mobilemenubtn" class="d-lg-none">
-		<div class="lines">
-			<span></span>
-			<span></span>
-			<span></span>
-		</div>
-	</button>
-	
-	<!-- Mobile menu -->
-	<nav class="mobilemenu" id="mobilemenu">
-		<ul class="menu-items">
-			{% include "partials/menu.twig" with {'items': mobielmenu.get_items} %}
-		</ul>
-	</nav>
+        <!-- Hamburger menu button -->
+        <button id="mobilemenubtn" class="d-lg-none">
+                <div class="lines">
+                        <span></span>
+                        <span></span>
+                        <span></span>
+                </div>
+        </button>
+
+        <!-- Mobile menu -->
+        <nav class="mobilemenu" id="mobilemenu">
+                <ul class="menu-items">
+                        {% include "partials/menu.twig" with {'items': mobielmenu.get_items} %}
+                </ul>
+        </nav>
 {% endif %}


### PR DESCRIPTION
## Summary
- add service menu registration and context
- introduce fixed topbar with description text and menu
- adjust styles so main header hides while topbar stays visible

## Testing
- `composer test` *(fails: Failed opening required '/workspace/skeletor/vendor/automattic/wordbless/src/../../../../wordpress//wp-settings.php')*

------
https://chatgpt.com/codex/tasks/task_e_689dbb98f4e88331adeb455ed0947fc9