### PR TITLE
Add mobile filter collapse and loading spinner

### DIFF
--- a/assets/js/scripts/filter.js
+++ b/assets/js/scripts/filter.js
@@ -64,12 +64,12 @@ export function filter() {
 	let currentPage = 1;
 	let maxPages = null;
 
-	const toggleLoader = (show) => {
-		const results = document.querySelector('#filter-results');
-		if (!results) return;
-
-		results.classList.toggle('loading', show);
-	};
+        const toggleLoader = (show) => {
+                const results = document.querySelector('#filter-results');
+                const loader = document.querySelector('[data-filter-loader]');
+                if (loader) loader.classList.toggle('d-none', !show);
+                if (results) results.classList.toggle('loading', show);
+        };
 
 	const animateItems = () => {
 		const items = resultContainer.querySelectorAll('.fade-in-item');

--- a/src/StarterSite.php
+++ b/src/StarterSite.php
@@ -8,11 +8,11 @@ use Timber\Site;
  */
 class StarterSite extends Site {
         public function __construct() {
-                add_action('after_setup_theme', [$this, 'theme_supports']);
-                add_filter('timber/context', [$this, 'add_to_context']);
-                add_filter('timber/twig', [$this, 'add_to_twig']);
-                add_filter('timber/twig/environment/options', [$this, 'update_twig_environment_options']);
-                add_filter('body_class', [$this, 'add_body_class']);
+            add_action('after_setup_theme', [$this, 'theme_supports']);
+            add_filter('timber/context', [$this, 'add_to_context']);
+            add_filter('timber/twig', [$this, 'add_to_twig']);
+            add_filter('timber/twig/environment/options', [$this, 'update_twig_environment_options']);
+            add_filter('body_class', [$this, 'add_body_class']);
 		
 		// Extra template-locaties toevoegen
 		Timber::$locations = [

--- a/views/archive-filter.twig
+++ b/views/archive-filter.twig
@@ -35,27 +35,27 @@
 					</div>
 				</div>
 			</div>
-                        <div class="row">
-                                <div class="col-md-4">
-                                        <button class="btn btn-outline-dark w-100 d-md-none mb-3" type="button" data-bs-toggle="collapse" data-bs-target="#filtersCollapse" aria-expanded="false" aria-controls="filtersCollapse">
-                                                <i class="fa-solid fa-filter me-2"></i> Filter resultaten
-                                        </button>
+			<div class="row">
+				<div class="col-md-4">
+					<button class="btn btn-outline-dark w-100 d-md-none mb-3" type="button" data-bs-toggle="collapse" data-bs-target="#filtersCollapse" aria-expanded="false" aria-controls="filtersCollapse">
+						<i class="fa-solid fa-filter me-2"></i> Filter resultaten
+					</button>
 
-                                        <div class="collapse d-md-block" id="filtersCollapse">
-                                                <div class="row mb-4">
-                                                        <div class="col">
-                                                                <h4 class="m-0"> {{ title }} </h4>
-                                                        </div>
-                                                        <div class="col-auto">
-                                                                <button type="reset" class="btn btn-sm btn-outline-dark" data-filter-reset>
-                                                                        Reset filters
-                                                                </button>
-                                                        </div>
-                                                </div>
+					<div class="collapse d-md-block" id="filtersCollapse">
+						<div class="row mb-4">
+							<div class="col">
+								<h4 class="m-0"> {{ title }} </h4>
+							</div>
+							<div class="col-auto">
+								<button type="reset" class="btn btn-sm btn-outline-dark" data-filter-reset>
+									Reset filters
+								</button>
+							</div>
+						</div>
 
-                                                <input type="text" name="s" class="form-control mb-4" placeholder="Zoek op trefwoord..." value="{{ filters.s.value|e }}">
+						<input type="text" name="s" class="form-control mb-4" placeholder="Zoek op trefwoord..." value="{{ filters.s.value|e }}">
 
-                                                {{ filter(filters.uren, {
+						{{ filter(filters.uren, {
                                                         limit_options: 5,
                                                         option_list_expand_label: 'Meer opties',
                                                         option_list_collapse_label: 'Minder opties',
@@ -65,22 +65,22 @@
                                                         show_option_counts: true
                                                 }) }}
 
-                                                {{ filter(filters.prijs) }}
+						{{ filter(filters.prijs) }}
 
-                                                {{ filter(filters.vakgebied, {
+						{{ filter(filters.vakgebied, {
                                                         label: 'Vakgebied',
                                                         show_field_label: true,
                                                         layout: 'horizontal',
                                                         button_class: 'btn-outline-dark',
                                                         all_label: 'Alle'
                                                 }) }}
-                                        </div>
-                                </div>
-                                <div class="col-md-8">
-                                        <div class="position-relative">
-                                                <div id="filter-loader" data-filter-loader class="filter-overlay d-none">
-                                                        <div class="spinner-border text-secondary" role="status" aria-hidden="true"></div>
-                                                </div>
+					</div>
+				</div>
+				<div class="col-md-8">
+					<div class="position-relative">
+						<div id="filter-loader" data-filter-loader class="filter-overlay d-none">
+							<div class="spinner-border text-secondary" role="status" aria-hidden="true"></div>
+						</div>
 
 						<div id="filter-results">
 

--- a/views/archive-filter.twig
+++ b/views/archive-filter.twig
@@ -35,46 +35,52 @@
 					</div>
 				</div>
 			</div>
-			<div class="row">
-				<div class="col-md-4">
-					<div class="row mb-4">
-						<div class="col">
-							<h4 class="m-0"> {{ title }} </h4>
-						</div>
-						<div class="col-auto">
-							<button type="reset" class="btn btn-sm btn-outline-dark" data-filter-reset>
-								Reset filters
-							</button>
-						</div>
-					</div>
+                        <div class="row">
+                                <div class="col-md-4">
+                                        <button class="btn btn-outline-dark w-100 d-md-none mb-3" type="button" data-bs-toggle="collapse" data-bs-target="#filtersCollapse" aria-expanded="false" aria-controls="filtersCollapse">
+                                                <i class="fa-solid fa-filter me-2"></i> Filter resultaten
+                                        </button>
 
-					<input type="text" name="s" class="form-control mb-4" placeholder="Zoek op trefwoord..." value="{{ filters.s.value|e }}">
+                                        <div class="collapse d-md-block" id="filtersCollapse">
+                                                <div class="row mb-4">
+                                                        <div class="col">
+                                                                <h4 class="m-0"> {{ title }} </h4>
+                                                        </div>
+                                                        <div class="col-auto">
+                                                                <button type="reset" class="btn btn-sm btn-outline-dark" data-filter-reset>
+                                                                        Reset filters
+                                                                </button>
+                                                        </div>
+                                                </div>
 
-					{{ filter(filters.uren, {
-						limit_options: 5,
-						option_list_expand_label: 'Meer opties',
-						option_list_collapse_label: 'Minder opties',
-						layout: 'vertical',
-						show_field_label: true,
-						label: 'Alle uren',
-						show_option_counts: true
-					}) }}
+                                                <input type="text" name="s" class="form-control mb-4" placeholder="Zoek op trefwoord..." value="{{ filters.s.value|e }}">
 
-					{{ filter(filters.prijs) }}
+                                                {{ filter(filters.uren, {
+                                                        limit_options: 5,
+                                                        option_list_expand_label: 'Meer opties',
+                                                        option_list_collapse_label: 'Minder opties',
+                                                        layout: 'vertical',
+                                                        show_field_label: true,
+                                                        label: 'Alle uren',
+                                                        show_option_counts: true
+                                                }) }}
 
-					{{ filter(filters.vakgebied, {
-						label: 'Vakgebied',
-						show_field_label: true,
-						  layout: 'horizontal',                 
-						  button_class: 'btn-outline-dark',  
-						  all_label: 'Alle'
-					}) }}
-				</div>
-				<div class="col-md-8">
-					<div class="position-relative">
-						<div id="filter-loader" data-filter-loader class="filter-overlay d-none">
-							<div class="spinner-border text-secondary" role="status" aria-hidden="true"></div>
-						</div>
+                                                {{ filter(filters.prijs) }}
+
+                                                {{ filter(filters.vakgebied, {
+                                                        label: 'Vakgebied',
+                                                        show_field_label: true,
+                                                        layout: 'horizontal',
+                                                        button_class: 'btn-outline-dark',
+                                                        all_label: 'Alle'
+                                                }) }}
+                                        </div>
+                                </div>
+                                <div class="col-md-8">
+                                        <div class="position-relative">
+                                                <div id="filter-loader" data-filter-loader class="filter-overlay d-none">
+                                                        <div class="spinner-border text-secondary" role="status" aria-hidden="true"></div>
+                                                </div>
 
 						<div id="filter-results">
 

--- a/views/archive-locaties.twig
+++ b/views/archive-locaties.twig
@@ -16,7 +16,7 @@
 						<div class="row">
 							<div class="col-sm d-flex align-items-center">
 								{% if total is defined %}
-								<p id="result-count" class="m-0" data-result-count>{{ total }} resultaten gevonden</p>
+									<p id="result-count" class="m-0" data-result-count>{{ total }} resultaten gevonden</p>
 								{% endif %}
 							</div>
 							<div class="col-sm-auto d-flex align-items-center">
@@ -36,40 +36,40 @@
 				</div>
 			</div>
 			<div class="row">
-                                <div class="col-md-4">
-                                        <button class="btn btn-outline-dark w-100 d-md-none mb-3" type="button" data-bs-toggle="collapse" data-bs-target="#filtersCollapse" aria-expanded="false" aria-controls="filtersCollapse">
-                                                <i class="fa-solid fa-filter me-2"></i> Filter resultaten
-                                        </button>
+                <div class="col-md-4">
+                        <button class="btn btn-outline-dark w-100 d-md-none mb-3" type="button" data-bs-toggle="collapse" data-bs-target="#filtersCollapse" aria-expanded="false" aria-controls="filtersCollapse">
+                                <i class="fa-solid fa-filter me-2"></i> Filter resultaten
+                        </button>
 
-                                        <div class="collapse d-md-block" id="filtersCollapse">
-                                                <div class="row mb-4">
-                                                        <div class="col">
-                                                                <h4 class="m-0"> {{ title }} </h4>
-                                                        </div>
-                                                        <div class="col-auto">
-                                                                <button type="reset" class="btn btn-sm btn-outline-dark" data-filter-reset>
-                                                                        Reset filters
-                                                                </button>
-                                                        </div>
-                                                </div>
-
-                                                <input type="text" name="s" class="form-control mb-4" placeholder="Zoek op trefwoord..." value="{{ filters.s.value|e }}">
-
-                                                {{ filter(filters.published) }}
-
-                                                {{ filter(filters.rating) }}
-
-                                                {{ filter(filters.provincies, {
-                                                        limit_options: 3,
-                                                        option_list_expand_label: 'Meer opties',
-                                                        option_list_collapse_label: 'Minder opties',
-                                                        layout: 'vertical',
-                                                        show_field_label: true,
-                                                        label: 'Alle uren',
-                                                        show_option_counts: true
-                                                }) }}
+                        <div class="collapse d-md-block" id="filtersCollapse">
+                                <div class="row mb-4">
+                                        <div class="col">
+                                                <h4 class="m-0"> {{ title }} </h4>
+                                        </div>
+                                        <div class="col-auto">
+                                                <button type="reset" class="btn btn-sm btn-outline-dark" data-filter-reset>
+                                                        Reset filters
+                                                </button>
                                         </div>
                                 </div>
+
+                                <input type="text" name="s" class="form-control mb-4" placeholder="Zoek op trefwoord..." value="{{ filters.s.value|e }}">
+
+                                {{ filter(filters.published) }}
+
+                                {{ filter(filters.rating) }}
+
+                                {{ filter(filters.provincies, {
+                                        limit_options: 3,
+                                        option_list_expand_label: 'Meer opties',
+                                        option_list_collapse_label: 'Minder opties',
+                                        layout: 'vertical',
+                                        show_field_label: true,
+                                        label: 'Alle uren',
+                                        show_option_counts: true
+                                }) }}
+                        </div>
+                </div>
 				<div class="col-md-8">
 					<div class="position-relative">
 						<div id="filter-loader" data-filter-loader class="filter-overlay d-none">

--- a/views/archive-locaties.twig
+++ b/views/archive-locaties.twig
@@ -36,34 +36,40 @@
 				</div>
 			</div>
 			<div class="row">
-				<div class="col-md-4">
-					<div class="row mb-4">
-						<div class="col">
-							<h4 class="m-0"> {{ title }} </h4>
-						</div>
-						<div class="col-auto">
-							<button type="reset" class="btn btn-sm btn-outline-dark" data-filter-reset>
-								Reset filters
-							</button>
-						</div>
-					</div>
+                                <div class="col-md-4">
+                                        <button class="btn btn-outline-dark w-100 d-md-none mb-3" type="button" data-bs-toggle="collapse" data-bs-target="#filtersCollapse" aria-expanded="false" aria-controls="filtersCollapse">
+                                                <i class="fa-solid fa-filter me-2"></i> Filter resultaten
+                                        </button>
 
-                                        <input type="text" name="s" class="form-control mb-4" placeholder="Zoek op trefwoord..." value="{{ filters.s.value|e }}">
+                                        <div class="collapse d-md-block" id="filtersCollapse">
+                                                <div class="row mb-4">
+                                                        <div class="col">
+                                                                <h4 class="m-0"> {{ title }} </h4>
+                                                        </div>
+                                                        <div class="col-auto">
+                                                                <button type="reset" class="btn btn-sm btn-outline-dark" data-filter-reset>
+                                                                        Reset filters
+                                                                </button>
+                                                        </div>
+                                                </div>
 
-                                        {{ filter(filters.published) }}
-										
-										{{ filter(filters.rating) }}
-										
-                                        {{ filter(filters.provincies, {
-                                                limit_options: 3,
-                                                option_list_expand_label: 'Meer opties',
-                                                option_list_collapse_label: 'Minder opties',
-                                                layout: 'vertical',
-						show_field_label: true,
-						label: 'Alle uren',
-						show_option_counts: true
-					}) }}
-				</div>
+                                                <input type="text" name="s" class="form-control mb-4" placeholder="Zoek op trefwoord..." value="{{ filters.s.value|e }}">
+
+                                                {{ filter(filters.published) }}
+
+                                                {{ filter(filters.rating) }}
+
+                                                {{ filter(filters.provincies, {
+                                                        limit_options: 3,
+                                                        option_list_expand_label: 'Meer opties',
+                                                        option_list_collapse_label: 'Minder opties',
+                                                        layout: 'vertical',
+                                                        show_field_label: true,
+                                                        label: 'Alle uren',
+                                                        show_option_counts: true
+                                                }) }}
+                                        </div>
+                                </div>
 				<div class="col-md-8">
 					<div class="position-relative">
 						<div id="filter-loader" data-filter-loader class="filter-overlay d-none">


### PR DESCRIPTION
## Summary
- Wrap archive filters in a mobile collapse with a toggle button
- Show Bootstrap spinner overlay while AJAX results load

## Testing
- `composer test` *(fails: Failed opening required '.../wordpress//wp-settings.php')*


------
https://chatgpt.com/codex/tasks/task_e_689dec5b8fd88331b14637ada3428889