### PR TITLE
Allow configurable posts per page for archives

### DIFF
--- a/archive.php
+++ b/archive.php
@@ -13,9 +13,13 @@
 
 $context = Timber::context(); // Basiscontext vanuit Timber, bevat globale data (site, user, etc.)
 
-$post_type = get_post_type(); 
+$post_type = get_post_type();
 $context['post_type'] = $post_type; // Nodig voor AJAX (JS moet weten welk post_type gefilterd wordt)
 $context['filters'] = [];
+
+// 🔢 Aantal resultaten per pagina instelbaar
+$posts_per_page = 12;
+$context['posts_per_page'] = $posts_per_page;
 
 /**
  * 🧩 Filters
@@ -68,7 +72,7 @@ $context['filters']['published'] = [
  */
 $query_args = [
   'post_type'      => $post_type,
-  'posts_per_page' => 12,                     // Resultaten per pagina
+  'posts_per_page' => $posts_per_page,        // Resultaten per pagina
   'paged'          => get_query_var('paged') ?: 1, // Huidige paginanummer (voor paginatie)
 ];
 

--- a/components/library/filter/FilterAjax.php
+++ b/components/library/filter/FilterAjax.php
@@ -39,8 +39,9 @@ class Components_FilterAjax {
 			wp_die();
 		}
 	
-		$post_type = sanitize_text_field($filters['post_type'] ?? 'post');
-		$paged     = (int)($filters['paged'] ?? 1);
+               $post_type      = sanitize_text_field($filters['post_type'] ?? 'post');
+               $paged          = (int)($filters['paged'] ?? 1);
+               $posts_per_page = isset($filters['posts_per_page']) ? (int) $filters['posts_per_page'] : 12;
 	
                 // 🔍 Meta filters
                 $meta_query = [];
@@ -168,15 +169,15 @@ class Components_FilterAjax {
 		}
 		
 		// 🔍 WP_Query args
-                $args = [
-                        'post_type'      => $post_type,
-                        'post_status'    => 'publish',
-                        'posts_per_page' => 12,
-                        'paged'          => $paged,
-                        'orderby'        => $orderby,
-                        'order'          => $order,
-                        'meta_query'     => $meta_query,
-                ];
+               $args = [
+                       'post_type'      => $post_type,
+                       'post_status'    => 'publish',
+                       'posts_per_page' => $posts_per_page,
+                       'paged'          => $paged,
+                       'orderby'        => $orderby,
+                       'order'          => $order,
+                       'meta_query'     => $meta_query,
+               ];
                 if (!empty($date_query)) {
                         $args['date_query'] = $date_query;
                 }
@@ -190,7 +191,7 @@ class Components_FilterAjax {
 		}
 
 		// 🔧 Filters doorgeven aan build_query_from_filters, excl. technische of al verwerkte keys
-		$exclude_keys = ['action', 'paged', 'post_type', 's', 'sort'];
+               $exclude_keys = ['action', 'paged', 'post_type', 's', 'sort', 'posts_per_page'];
 		$filter_definitions = [];
 
 		foreach ($filters as $key => $val) {

--- a/views/archive-filter.twig
+++ b/views/archive-filter.twig
@@ -6,7 +6,8 @@
 {% block content %}
 <section class="bg-greylight">
 	<div class="container">
-		<form data-filter-form data-post-type="{{ post_type }}">
+               <form data-filter-form data-post-type="{{ post_type }}">
+                       <input type="hidden" name="posts_per_page" value="{{ posts_per_page }}">
 			<div class="row mb-5">
 				<div class="col-md-4 d-flex align-items-center">
 					<a href="{{ site.link }}">Home </a> <span> / </span> {{ post_type|capitalize }}

--- a/views/archive-locaties.twig
+++ b/views/archive-locaties.twig
@@ -6,7 +6,8 @@
 {% block content %}
 <section class="bg-greylight">
 	<div class="container">
-		<form data-filter-form data-post-type="{{ post_type }}">
+               <form data-filter-form data-post-type="{{ post_type }}">
+                       <input type="hidden" name="posts_per_page" value="{{ posts_per_page }}">
 			<div class="row mb-5">
 				<div class="col-md-4 d-flex align-items-center">
 					<a href="{{ site.link }}">Home </a> <span> / </span> {{ post_type|capitalize }}

--- a/views/archive.twig
+++ b/views/archive.twig
@@ -6,7 +6,8 @@
 {% block content %}
 <section class="bg-greylight">
 	<div class="container">
-		<form data-filter-form data-post-type="{{ post_type }}">
+               <form data-filter-form data-post-type="{{ post_type }}">
+                       <input type="hidden" name="posts_per_page" value="{{ posts_per_page }}">
 			<div class="row mb-5">
 				<div class="col-md-4 d-flex align-items-center">
 					<a href="{{ site.link }}">Home </a> / {{ post_type|capitalize }}


### PR DESCRIPTION
## Summary
- Make number of posts per page configurable in archive query
- Pass posts-per-page to AJAX filter requests
- Add hidden field so templates honor custom posts-per-page value

## Testing
- `composer test` *(fails: Failed opening required '.../wordpress//wp-settings.php')*

------
https://chatgpt.com/codex/tasks/task_e_689e15b44b108331b7a53216d7b048e2