### PR TITLE
Align filter option counts to the right

### DIFF
--- a/components/library/filter/_filter.scss
+++ b/components/library/filter/_filter.scss
@@ -74,5 +74,24 @@
 }
 
 .noUi-connect {
-	background: $primary;
+    background: $primary;
+}
+
+// Align option counts to the right in checkbox and radio filters
+.filter-options-wrapper {
+    .form-check-label {
+        display: flex;
+        justify-content: space-between;
+        width: 100%;
+    }
+
+    .filter-option-label {
+        display: flex;
+        align-items: center;
+        gap: .5rem;
+    }
+
+    .filter-option-count {
+        text-align: right;
+    }
 }

--- a/components/library/filter/filter.twig
+++ b/components/library/filter/filter.twig
@@ -75,15 +75,17 @@ Beschikbare presentatie-opties:
 	{% set selected = value is iterable ? value : [value] %}
 	<div class="filter-options-wrapper" data-limit-options="{{ limit_options }}" data-expand-label="{{ option_list_expand_label }}" data-collapse-label="{{ option_list_collapse_label }}">
 		{% for key, val in options %}
-		<div class="form-check">
-			<label class="form-check-label">
-				<input class="form-check-input" type="{{ type }}" name="{{ name }}{% if type == 'checkbox' %}[]{% endif %}" value="{{ val }}" {% if val in selected %}checked{% endif %}>
-                                {{ key }}
+                <div class="form-check">
+                        <label class="form-check-label">
+                                <span class="filter-option-label">
+                                        <input class="form-check-input" type="{{ type }}" name="{{ name }}{% if type == 'checkbox' %}[]{% endif %}" value="{{ val }}" {% if val in selected %}checked{% endif %}>
+                                        {{ key }}
+                                </span>
             {% if show_option_counts and option_counts[val] is defined %}
-              (<span class="filter-option-count" data-option-count="{{ name }}:{{ val }}">{{ option_counts[val] }}</span>)
+                <span class="filter-option-count" data-option-count="{{ name }}:{{ val }}">{{ option_counts[val] }}</span>
             {% endif %}
-			</label>
-		</div>
+                        </label>
+                </div>
 		{% endfor %}
 
 		<button type="button" class="btn btn-sm btn-link filter-toggle-btn d-none" aria-expanded="false"></button>


### PR DESCRIPTION
## Summary
- Align checkbox and radio filter counts to the right using flex layout
- Add styles to support right-aligned option counts in filter component

## Testing
- `composer test` *(fails: Failed opening required '/workspace/skeletor/vendor/automattic/wordbless/src/../../../../wordpress//wp-settings.php')*

------
https://chatgpt.com/codex/tasks/task_e_689e4df01c7883318c13c6c0aaee9932