### PR TITLE
Add WooCommerce product filters and stock display

### DIFF
--- a/archive-product.php
+++ b/archive-product.php
@@ -11,6 +11,12 @@ use Timber\Timber;
 $context = Timber::context();
 $templates = ['woo/archive.twig']; // Gebruik de WooCommerce specifieke Twig-template
 
+// ⚙️ Basisinstellingen voor filters
+$posts_per_page = 12;
+$context['posts_per_page'] = $posts_per_page;
+$context['post_type'] = 'product';
+$context['filters'] = [];
+
 // ✅ Stel de juiste titel in voor de shop pagina en categorieën
 if (is_shop()) {
     $context['title'] = get_the_title(wc_get_page_id('shop')); // WooCommerce shop pagina titel
@@ -20,8 +26,53 @@ if (is_shop()) {
     $context['title'] = post_type_archive_title('', false);
 }
 
+// 🧩 Filters voor WooCommerce producten
+$context['filters']['price'] = [
+    'name'   => '_price',
+    'label'  => 'Prijs',
+    'type'   => 'range',
+    'source' => 'meta',
+];
+
+$context['filters']['stock'] = [
+    'name'   => '_stock',
+    'label'  => 'Voorraad',
+    'type'   => 'range',
+    'source' => 'meta',
+];
+
+$context['filters']['stock_status'] = [
+    'name'    => '_stock_status',
+    'label'   => 'Beschikbaarheid',
+    'type'    => 'select',
+    'source'  => 'meta',
+    'options' => [
+        'Op voorraad' => 'instock',
+        'Uitverkocht' => 'outofstock',
+    ],
+];
+
+// 🔎 Query bouwen op basis van filters
+$query_args = [
+    'post_type'      => 'product',
+    'posts_per_page' => $posts_per_page,
+    'paged'          => get_query_var('paged') ?: 1,
+];
+
+$query_args = array_merge(
+    $query_args,
+    Components_Filter::build_query_from_filters($context['filters'])
+);
+
+$query = new WP_Query($query_args);
+
 // ✅ Haal producten op met Timber
-$context['products'] = Timber::get_posts();
+$context['products']       = Timber::get_posts($query);
+$context['total']          = $query->found_posts;
+$context['current_page']   = get_query_var('paged') ?: 1;
+$context['max_num_pages']  = $query->max_num_pages;
+$context['ajax_filters']   = $context['filters'];
+set_transient('components_ajax_filters_product', $context['filters'], DAY_IN_SECONDS);
 
 // ✅ Controleer of er een sidebar is ingesteld voor de shop
 $widgets = Timber::get_widgets('shop-sidebar');

--- a/components/library/filter/Filter.php
+++ b/components/library/filter/Filter.php
@@ -11,7 +11,7 @@
  *   'name'       => 'uren',                   // input name, ook gebruikt in GET
  *   'label'      => 'Uren',                   // veldlabel
  *   'type'       => 'checkbox',               // 'select', 'checkbox', 'radio', 'buttons', 'range', 'date', 'date_range'
- *   'source'     => 'acf',                    // 'acf', 'taxonomy' of 'post_date'
+ *   'source'     => 'acf',                    // 'acf', 'meta', 'taxonomy' of 'post_date'
  *   'value'      => $_GET['uren'] ?? null,    // huidige waarde (optioneel)
  *   'options'    => Components_Filter::get_options_from_meta('uren'), // array met key => value
  *   'date_format'=> 'd-m-Y',                 // formaat voor datumvelden (optioneel)
@@ -26,7 +26,7 @@
  *   'name'   => 'event_date',           // ACF-veldnaam of 'post_date'
  *   'label'  => 'Datum',
  *   'type'   => 'date_range',           // 'date' voor enkel veld
- *   'source' => 'acf',                 // of 'post_date'
+*   'source' => 'acf',                 // or 'meta' or 'post_date'
  *   // Waarden worden automatisch uit $_GET['event_date'] of
  *   // $_GET['from_event_date']/$_GET['to_event_date'] gelezen.
  *   // Wanneer geen waardes worden meegegeven vult het component
@@ -68,7 +68,7 @@ class Components_Filter extends Site {
 		$type   = $data['type'] ?? 'select';
                 $source = $data['source'] ?? 'acf';
 
-                if (!$name || !in_array($source, ['acf', 'taxonomy', 'post_date'])) {
+                if (!$name || !in_array($source, ['acf', 'meta', 'taxonomy', 'post_date'])) {
                         return "<pre>❌ Ongeldige filterconfiguratie\n" . print_r($data, true) . "</pre>";
                 }
 	
@@ -122,17 +122,17 @@ class Components_Filter extends Site {
 		}
 	
 		// 🧾 Opties ophalen indien leeg
-		if (!isset($data['options']) || empty($data['options'])) {
-			if ($source === 'acf') {
-				$data['options'] = self::get_options_from_meta($name);
-			} elseif ($source === 'taxonomy') {
-				$data['options'] = self::get_options_from_taxonomy(
-					$name,
-					'name',
-					$data['hide_empty_options'] ?? false
-				);
-			}
-		}
+                if (!isset($data['options']) || empty($data['options'])) {
+                        if ($source === 'acf' || $source === 'meta') {
+                                $data['options'] = self::get_options_from_meta($name);
+                        } elseif ($source === 'taxonomy') {
+                                $data['options'] = self::get_options_from_taxonomy(
+                                        $name,
+                                        'name',
+                                        $data['hide_empty_options'] ?? false
+                                );
+                        }
+                }
 	
                // 🧮 Tellingen ophalen als gewenst
                if (($args['show_option_counts'] ?? false) && isset($data['name'])) {
@@ -307,8 +307,8 @@ class Components_Filter extends Site {
        /**
         * Bepaalt automatisch de oudste en nieuwste datum voor een veld of publicatiedatum.
         *
-        * @param string $field      Meta key of special value 'post_date'.
-        * @param string $source     'acf' of 'post_date'.
+        * @param string $field      Meta key or special value 'post_date'.
+        * @param string $source     'acf', 'meta' or 'post_date'.
         * @param string $post_type  Optioneel post type (default huidige query).
         * @return array ['min' => 'd-m-Y', 'max' => 'd-m-Y']
         */
@@ -463,7 +463,7 @@ class Components_Filter extends Site {
                         }
 
                         // 🟡 ACF (meta)
-                        elseif ($source === 'acf' && !empty($value)) {
+                        elseif (($source === 'acf' || $source === 'meta') && !empty($value)) {
                                 $meta_query[] = [
                                         'key'     => $name,
                                         'value'   => is_array($value) ? $value : [$value],

--- a/components/library/filter/FilterAjax.php
+++ b/components/library/filter/FilterAjax.php
@@ -201,10 +201,11 @@ class Components_FilterAjax {
 
                         if (str_starts_with($key, 'min_') || str_starts_with($key, 'max_') || str_starts_with($key, 'from_') || str_starts_with($key, 'to_')) continue;
 
-			$filter_definitions[$key] = [
-				'acf_field' => $key,
-				'value'     => $filters[$key]
-			];
+                        $filter_definitions[$key] = [
+                                'name'   => $key,
+                                'source' => 'meta',
+                                'value'  => $filters[$key]
+                        ];
 		}
 
 		// 🧠 Combineer custom filter-output met bestaande query args
@@ -246,7 +247,7 @@ class Components_FilterAjax {
 
                foreach ($filter_defs_for_counts as $fname => &$def) {
                        $ftype = $def['type'] ?? 'select';
-                       $fsrc  = $def['source'] ?? 'acf';
+                       $fsrc  = $def['source'] ?? 'meta';
                        $key   = $def['name'] ?? $fname;
 
                        if ($ftype === 'range') {
@@ -270,7 +271,7 @@ class Components_FilterAjax {
                        }
 
                        if (empty($def['options'])) {
-                               if ($fsrc === 'acf') {
+                               if ($fsrc === 'acf' || $fsrc === 'meta') {
                                        $def['options'] = Components_Filter::get_options_from_meta($key);
                                } elseif ($fsrc === 'taxonomy') {
                                        $def['options'] = Components_Filter::get_options_from_taxonomy($key);

--- a/components/library/filter/FilterAjax.php
+++ b/components/library/filter/FilterAjax.php
@@ -194,19 +194,22 @@ class Components_FilterAjax {
                $exclude_keys = ['action', 'paged', 'post_type', 's', 'sort', 'posts_per_page'];
 		$filter_definitions = [];
 
-		foreach ($filters as $key => $val) {
-			if (in_array($key, $exclude_keys, true)) continue;
+foreach ($filters as $key => $val) {
+if (in_array($key, $exclude_keys, true)) continue;
 
-			if (taxonomy_exists($key)) continue;
+if (taxonomy_exists($key)) continue;
 
-                        if (str_starts_with($key, 'min_') || str_starts_with($key, 'max_') || str_starts_with($key, 'from_') || str_starts_with($key, 'to_')) continue;
+if (str_starts_with($key, 'min_') || str_starts_with($key, 'max_') || str_starts_with($key, 'from_') || str_starts_with($key, 'to_')) continue;
 
-                        $filter_definitions[$key] = [
-                                'name'   => $key,
-                                'source' => 'meta',
-                                'value'  => $filters[$key]
-                        ];
-		}
+$value = $filters[$key];
+if ($value === '' || $value === null || (is_array($value) && $value === [])) continue;
+
+$filter_definitions[$key] = [
+'name'   => $key,
+'source' => 'meta',
+'value'  => $value,
+];
+}
 
 		// 🧠 Combineer custom filter-output met bestaande query args
 		$custom_args = Components_Filter::build_query_from_filters($filter_definitions);

--- a/src/CustomWooCommerce.php
+++ b/src/CustomWooCommerce.php
@@ -64,12 +64,16 @@ class CustomWooCommerce extends Site {
 		// ✅ Forceer de juiste WooCommerce product afbeelding
 		$thumbnail = get_the_post_thumbnail_url($post->ID, 'woocommerce_single') ?: wc_placeholder_img_src();
 
-		// ✅ Return Timber product data
-		return [
-			'product' => $product,
-			'thumbnail' => $thumbnail,
-		];
-	}
+                // ✅ Return Timber product data
+                return [
+                        'product'        => $product,
+                        'thumbnail'      => $thumbnail,
+                        'price_html'     => $product->get_price_html(),
+                        'stock_quantity' => $product->get_stock_quantity(),
+                        'stock_status'   => $product->get_stock_status(),
+                        'is_in_stock'    => $product->is_in_stock(),
+                ];
+        }
 
 	/**
 	 * Registreer WooCommerce-functies in Timber, zodat ze in Twig beschikbaar zijn.

--- a/views/partials/list.twig
+++ b/views/partials/list.twig
@@ -1,15 +1,15 @@
 {% if posts|length %}
-	<div class="row">
-		{% for item in posts %}
-			<div class="col-12 fade-in-item visible">
-				{# Probeer eerst tease-[post_type].twig, anders tease.twig #}
-				{% include [
-					'partials/tease-' ~ item.post_type ~ '.twig',
-					'partials/tease.twig'
-				] with { item: item } %}
-			</div>
-		{% endfor %}
-	</div>
+        <div class="row">
+                {% for item in posts %}
+                        <div class="{{ item.post_type == 'product' ? 'col-sm-6 col-lg-4 col-xxl-3' : 'col-12' }} fade-in-item visible">
+                                {# Probeer eerst tease-[post_type].twig, anders tease.twig #}
+                                {% include [
+                                        'partials/tease-' ~ item.post_type ~ '.twig',
+                                        'partials/tease.twig'
+                                ] with { item: item } %}
+                        </div>
+                {% endfor %}
+        </div>
 	<div data-max-pages="{{ max_pages|e('html_attr') }}" hidden></div>
 {% else %}
 	<p>Geen resultaten gevonden.</p>

--- a/views/partials/tease-product.twig
+++ b/views/partials/tease-product.twig
@@ -1,0 +1,2 @@
+{% include "woo/partials/tease-product.twig" with { post: item } %}
+

--- a/views/woo/archive.twig
+++ b/views/woo/archive.twig
@@ -9,6 +9,17 @@
             <input type="hidden" name="posts_per_page" value="{{ posts_per_page }}">
             <div class="row">
                 <div class="col-md-3 mb-4 mb-md-0">
+                    <div class="row mb-4">
+                        <div class="col">
+                            <h4 class="m-0">{{ title }}</h4>
+                        </div>
+                        <div class="col-auto">
+                            <button type="reset" class="btn btn-sm btn-outline-dark" data-filter-reset>
+                                Reset filters
+                            </button>
+                        </div>
+                    </div>
+
                     {{ filter(filters.price) }}
                     {{ filter(filters.stock) }}
                     {{ filter(filters.stock_status, {

--- a/views/woo/archive.twig
+++ b/views/woo/archive.twig
@@ -1,25 +1,54 @@
 {% extends 'base.twig' %}
 
 {% block content %}
-	<section>
-		<div class="container">
-			{% do action('woocommerce_before_main_content') %}
-		
-			<div class="before-shop-loop">
-				{% do action('woocommerce_before_shop_loop') %}
-			</div>
-		
-			<div class="row w-100">
-				{% for post in products %}
-					<div class="col-sm-6 col-lg-4 col-xxl-3">
-						{% include ["woo/partials/tease-product.twig"] %}
-					</div>
-				{% endfor %}
-			</div>
-		
-			{% do action('woocommerce_after_shop_loop') %}
-			{% do action('woocommerce_after_main_content') %}
-		</div>
-	</section>
+<section>
+    <div class="container">
+        {% do action('woocommerce_before_main_content') %}
 
-{% endblock  %}
+        <form data-filter-form data-post-type="product">
+            <input type="hidden" name="posts_per_page" value="{{ posts_per_page }}">
+            <div class="row">
+                <div class="col-md-3 mb-4 mb-md-0">
+                    {{ filter(filters.price) }}
+                    {{ filter(filters.stock) }}
+                    {{ filter(filters.stock_status, {
+                        label: 'Beschikbaarheid',
+                        show_field_label: true
+                    }) }}
+                </div>
+                <div class="col-md-9">
+                    <div class="before-shop-loop">
+                        {% do action('woocommerce_before_shop_loop') %}
+                    </div>
+
+                    <div class="position-relative">
+                        <div id="filter-loader" data-filter-loader class="filter-overlay d-none">
+                            <div class="spinner-border text-secondary" role="status" aria-hidden="true"></div>
+                        </div>
+
+                        <div id="filter-results">
+                            {% set posts = products %}
+                            {% set max_pages = max_num_pages %}
+                            {% include 'partials/list.twig' %}
+                        </div>
+
+                        {% if current_page < max_num_pages %}
+                        <div class="text-center mt-4">
+                            <button type="button" class="btn btn-outline-dark" data-load-more>
+                                Laad meer
+                            </button>
+                        </div>
+                        {% endif %}
+                    </div>
+
+                    <div class="after-shop-loop">
+                        {% do action('woocommerce_after_shop_loop') %}
+                    </div>
+                </div>
+            </div>
+        </form>
+
+        {% do action('woocommerce_after_main_content') %}
+    </div>
+</section>
+{% endblock %}

--- a/views/woo/partials/tease-product.twig
+++ b/views/woo/partials/tease-product.twig
@@ -4,30 +4,37 @@
 	
 	<div class="media">
 
-		<div class="media-figure {% if not product_data.thumbnail %}placeholder{% endif %}">
-			<a href="{{ post.link }}">
-				{% if product_data.thumbnail %}
-					<img src="{{ product_data.thumbnail }}" alt="{{ post.title }}" />
-				{% else %}
-					<span class="thumb-placeholder"><i class="icon-camera"></i></span>
-				{% endif %}
-			</a>
-		</div>
-			
-		<div class="media-content">
+        <div class="media-figure {% if not product_data.thumbnail %}placeholder{% endif %}">
+                <a href="{{ post.link }}">
+                        {% if product_data.thumbnail %}
+                                <img src="{{ product_data.thumbnail }}" alt="{{ post.title }}" />
+                        {% else %}
+                                <span class="thumb-placeholder"><i class="icon-camera"></i></span>
+                        {% endif %}
+                </a>
+                {% if not product_data.is_in_stock %}
+                        <span class="badge bg-danger out-of-stock">Uitverkocht</span>
+                {% endif %}
+        </div>
 
-			{% do action('woocommerce_before_shop_loop_item_title') %}
+        <div class="media-content">
 
-			{% if post.title %}
-				<h3 class="h4 entry-title"><a href="{{ post.link }}">{{ post.title }}</a></h3>
-			{% else %}
-				<h3 class="h4 entry-title"><a href="{{ post.link }}">{{ fn('the_title') }}</a></h3>
-			{% endif %}
+                {% if post.title %}
+                        <h3 class="h4 entry-title"><a href="{{ post.link }}">{{ post.title }}</a></h3>
+                {% else %}
+                        <h3 class="h4 entry-title"><a href="{{ post.link }}">{{ fn('the_title') }}</a></h3>
+                {% endif %}
 
-			{% do action( 'woocommerce_after_shop_loop_item_title' ) %}
-			{% do action( 'woocommerce_after_shop_loop_item' ) %}
+                <p class="price">{{ product_data.price_html }}</p>
+                {% if product_data.is_in_stock %}
+                        <p class="stock">{{ product_data.stock_quantity }} op voorraad</p>
+                {% else %}
+                        <p class="stock text-danger">Uitverkocht</p>
+                {% endif %}
 
-		</div>
+                {% do action('woocommerce_after_shop_loop_item') %}
+
+        </div>
 
 	</div>
 


### PR DESCRIPTION
## Summary
- switch WooCommerce archive filters to use product meta instead of ACF
- extend filter utilities and AJAX handler to support `meta` sources
- hook product archive into generic filter list with load-more and grid columns

## Testing
- `composer test` *(fails: Failed opening required wp-settings.php)*

------
https://chatgpt.com/codex/tasks/task_e_689f1f0c647483318e23e5e7e8b4d585