### PR TITLE
Add filterable search page with post type filter

### DIFF
--- a/search.php
+++ b/search.php
@@ -1,18 +1,98 @@
 <?php
 /**
- * Search results page
+ * Enhanced search results page with filter components and load more.
  *
- * Methods for TimberHelper can be found in the /lib sub-directory
- *
- * @package  WordPress
- * @subpackage  Timber
- * @since   Timber 0.1
+ * @package WordPress
+ * @subpackage Timber
  */
 
-$templates = array( 'search.twig', 'archive.twig', 'index.twig' );
+$templates = ['search.twig', 'archive.twig', 'index.twig'];
 
-$context          = Timber::context();
-$context['title'] = 'Search results for ' . get_search_query();
-$context['posts'] = Timber::get_posts();
+$context = Timber::context();
 
-Timber::render( $templates, $context );
+$posts_per_page = 12;
+$context['posts_per_page'] = $posts_per_page;
+
+$post_type = sanitize_text_field($_GET['post_type'] ?? 'post');
+$context['post_type'] = $post_type;
+
+$filters = [];
+
+if ($post_type === 'product') {
+    $filters['price'] = [
+        'name'   => '_price',
+        'label'  => 'Prijs',
+        'type'   => 'range',
+        'source' => 'meta',
+    ];
+    $filters['stock_status'] = [
+        'name'    => '_stock_status',
+        'label'   => 'Beschikbaarheid',
+        'type'    => 'select',
+        'source'  => 'meta',
+        'options' => [
+            'Op voorraad' => 'instock',
+            'Uitverkocht' => 'outofstock',
+        ],
+    ];
+} else {
+    $filters['provincies'] = [
+        'name'   => 'provincies',
+        'label'  => 'Provincies',
+        'type'   => 'checkbox',
+        'source' => 'taxonomy',
+        'hide_empty_options' => true,
+    ];
+    $filters['rating'] = [
+        'name'   => 'rating',
+        'label'  => 'Rating',
+        'type'   => 'range',
+        'source' => 'acf',
+    ];
+    $filters['published'] = [
+        'name'   => 'post_date',
+        'label'  => 'Periode',
+        'type'   => 'date_range',
+        'source' => 'post_date',
+    ];
+}
+
+$context['filters'] = $filters;
+
+$query_args = [
+    'post_type'      => $post_type,
+    'posts_per_page' => $posts_per_page,
+    'paged'          => get_query_var('paged') ?: 1,
+    's'              => get_search_query(),
+];
+
+$query_args = array_merge(
+    $query_args,
+    Components_Filter::build_query_from_filters($filters)
+);
+
+$query = new WP_Query($query_args);
+
+$context['posts']         = Timber::get_posts($query);
+$context['total']         = $query->found_posts;
+$context['current_page']  = get_query_var('paged') ?: 1;
+$context['max_num_pages'] = $query->max_num_pages;
+$context['title']         = 'Zoekresultaten voor ' . get_search_query();
+
+$context['ajax_filters'] = $filters;
+set_transient('components_ajax_filters_' . $post_type, $filters, DAY_IN_SECONDS);
+
+$context['filters']['post_type'] = [
+    'name'   => 'post_type',
+    'label'  => 'Type',
+    'type'   => 'select',
+    'source' => 'acf',
+    'options'=> [
+        'Berichten' => 'post',
+        'Producten' => 'product',
+    ],
+    'value'  => $post_type,
+];
+
+Timber::render($templates, $context);
+

--- a/views/search.twig
+++ b/views/search.twig
@@ -1,13 +1,82 @@
-{# see `archive.twig` for an alternative strategy of extending templates #}
-{% extends "base.twig" %}
+{% extends "index.twig" %}
 
 {% block content %}
-  {# see `base.twig:27` for where this block's content will be inserted #}
-  <div class="content-wrapper">
-    {% for post in posts %}
-      {% include ['tease-'~post.post_type~'.twig', 'tease.twig'] %}
-    {% endfor %}
+<section class="bg-greylight">
+    <div class="container">
+        <form data-filter-form data-post-type="{{ post_type }}">
+            <input type="hidden" name="posts_per_page" value="{{ posts_per_page }}">
 
-    {% include 'partial/pagination.twig' with { pagination: posts.pagination({show_all: false, mid_size: 3, end_size: 2}) } %}
-  </div>
+            <div class="row mb-5">
+                <div class="col-md-4 d-flex align-items-center">
+                    <a href="{{ site.link }}">Home </a> / Zoek
+                </div>
+                <div class="col-md-8 d-flex align-items-center">
+                    <div class="w-100">
+                        <div class="row">
+                            <div class="col-sm d-flex align-items-center">
+                                {% if total is defined %}
+                                <p id="result-count" class="m-0" data-result-count>{{ total }} resultaten gevonden</p>
+                                {% endif %}
+                            </div>
+                            <div class="col-sm-auto d-flex align-items-center">
+                                {{ sort_select(filters.sort, {
+                                    layout: 'horizontal',
+                                    options: {
+                                        'relevance': 'Relevantie',
+                                        'date_desc': 'Nieuwste eerst',
+                                        'date_asc': 'Oudste eerst',
+                                        'title_asc': 'Titel A-Z',
+                                        'title_desc': 'Titel Z-A'
+                                    }
+                                }) }}
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            <div class="row mb-4">
+                <div class="col">
+                    <h4 class="m-0">{{ title }}</h4>
+                </div>
+                <div class="col-auto">
+                    <button type="reset" class="btn btn-sm btn-outline-dark" data-filter-reset>Reset filters</button>
+                </div>
+            </div>
+
+            <input type="text" name="s" class="form-control mb-4" placeholder="Zoek op trefwoord..." value="{{ filters.s.value|e }}">
+
+            {{ filter('post_type', {
+                label: 'Type',
+                show_field_label: true,
+                layout: 'horizontal',
+                button_class: 'btn-outline-dark',
+                all_label: 'Alle'
+            }) }}
+
+            {% for name, f in filters %}
+                {% if name not in ['post_type'] %}
+                    {{ filter(f) }}
+                {% endif %}
+            {% endfor %}
+
+            <div class="position-relative">
+                <div id="filter-loader" data-filter-loader class="filter-overlay d-none">
+                    <div class="spinner-border text-secondary" role="status" aria-hidden="true"></div>
+                </div>
+
+                <div id="filter-results">
+                    {% include 'partials/list.twig' %}
+                </div>
+
+                {% if current_page < max_num_pages %}
+                <div class="text-center mt-4">
+                    <button type="button" class="btn btn-outline-dark" data-load-more>Laad meer</button>
+                </div>
+                {% endif %}
+            </div>
+        </form>
+    </div>
+</section>
 {% endblock %}
+


### PR DESCRIPTION
## Summary
- enhance `search.php` to build filterable queries and support post/product specific filters
- redesign search results template with sort, post type filter, and load-more UI

## Testing
- `composer test` *(fails: Failed opening required '/workspace/skeletor/vendor/automattic/wordbless/src/../../../../wordpress//wp-settings.php')*

------
https://chatgpt.com/codex/tasks/task_e_68a02f2c72b88331865eaa90137e6e0d