### PR TITLE
Fix search results and post type filter on search page

### DIFF
--- a/assets/js/scripts/filter.js
+++ b/assets/js/scripts/filter.js
@@ -25,37 +25,46 @@ export function filter() {
                 const grouped = {};
 
                 form.querySelectorAll('input, select, textarea').forEach((el) => {
-			if (!el.name || el.disabled) return;
-			const name = el.name.replace(/\[\]$/, '');
+                        if (!el.name || el.disabled) return;
 
-			if (el.type === 'checkbox') {
-				if (el.checked) {
-					if (!grouped[name]) grouped[name] = [];
-					grouped[name].push(el.value);
-				}
-			} else if (el.type === 'radio') {
-				if (el.checked) {
-					grouped[name] = el.value;
-				}
-			} else if (el.tagName === 'SELECT' && el.multiple) {
-				if (!grouped[name]) grouped[name] = [];
-				Array.from(el.selectedOptions).forEach(opt => grouped[name].push(opt.value));
-			} else {
-				grouped[name] = el.value;
-			}
-		});
+                        const rawName = el.name;
+                        const isArray = rawName.endsWith('[]');
+                        const name = rawName.replace(/\[\]$/, '');
 
-		for (const key in grouped) {
-			const value = grouped[key];
-			if (Array.isArray(value)) {
-				value.forEach(v => data.append(`${key}[]`, v));
-			} else {
-				data.append(key, value);
-			}
-		}
+                        if (el.type === 'checkbox') {
+                                if (el.checked) {
+                                        if (!grouped[name]) grouped[name] = [];
+                                        grouped[name].push(el.value);
+                                }
+                        } else if (el.type === 'radio') {
+                                if (el.checked) {
+                                        grouped[name] = el.value;
+                                }
+                        } else if (el.tagName === 'SELECT' && el.multiple) {
+                                if (!grouped[name]) grouped[name] = [];
+                                Array.from(el.selectedOptions).forEach(opt => grouped[name].push(opt.value));
+                        } else if (isArray) {
+                                if (!grouped[name]) grouped[name] = [];
+                                grouped[name].push(el.value);
+                        } else {
+                                grouped[name] = el.value;
+                        }
+                });
+
+                if (!('post_type' in grouped)) {
+                        grouped['post_type'] = form.dataset.postType || 'post';
+                }
+
+                for (const key in grouped) {
+                        const value = grouped[key];
+                        if (Array.isArray(value)) {
+                                value.forEach(v => data.append(`${key}[]`, v));
+                        } else {
+                                data.append(key, value);
+                        }
+                }
 
                 data.append('action', 'ajax_filter');
-                data.append('post_type', form.dataset.postType || 'post');
                 return data;
         };
 
@@ -237,6 +246,14 @@ export function filter() {
 
         const fetchFilteredResults = (append = false) => {
                 const data = serializeForm(filterForm);
+                const colClassField = filterForm.querySelector('input[name="col_class"]');
+                if (colClassField) {
+                        data.set('col_class', colClassField.value);
+                }
+                const teaseTemplateField = filterForm.querySelector('input[name="tease_template"]');
+                if (teaseTemplateField) {
+                        data.set('tease_template', teaseTemplateField.value);
+                }
                 if (wcOrderSelect) {
                         const selected = wcOrderSelect.options[wcOrderSelect.selectedIndex];
                         if (selected && selected.dataset.order) {

--- a/components/library/filter/filter.twig
+++ b/components/library/filter/filter.twig
@@ -51,31 +51,49 @@ Beschikbare presentatie-opties:
 {% set option_list_expand_label = option_list_expand_label ?? 'Toon meer' %}
 {% set option_list_collapse_label = option_list_collapse_label ?? 'Toon minder' %}
 {% set date_format = date_format ?? 'd-m-Y' %}
+{% set layout = layout ?? null %}
 
 {% if not name %}
   <pre>❌ Ongeldige filterdata ontvangen</pre>
 {% else %}
 
 <div class="mb-4">
-	{% if label and show_field_label %}
-	<label class="form-label">{{ label }}</label>
-	{% endif %}
+        {# Single Select #}
+        {% if type == 'select' %}
+        {% set select_layout = layout ?? 'vertical' %}
+        {% if select_layout == 'horizontal' %}
+        <div class="d-flex align-items-center gap-2">
+                {% if label and show_field_label %}
+                <label class="form-label mb-0">{{ label }}</label>
+                {% endif %}
+                <select name="{{ name }}" class="form-select">
+                        <option value="">{{ placeholder }}</option>
+                        {% for key, val in options %}
+                        <option value="{{ val }}" {{ val == value ? 'selected' : '' }}>{{ key }}</option>
+                        {% endfor %}
+                </select>
+        </div>
+        {% else %}
+                {% if label and show_field_label %}
+                <label class="form-label">{{ label }}</label>
+                {% endif %}
+                <select name="{{ name }}" class="form-select">
+                        <option value="">{{ placeholder }}</option>
+                        {% for key, val in options %}
+                        <option value="{{ val }}" {{ val == value ? 'selected' : '' }}>{{ key }}</option>
+                        {% endfor %}
+                </select>
+        {% endif %}
 
-	{# Single Select #}
-	{% if type == 'select' %}
-	<select name="{{ name }}" class="form-select">
-		<option value="">{{ placeholder }}</option>
-		{% for key, val in options %}
-		<option value="{{ val }}" {{ val == value ? 'selected' : '' }}>{{ key }}</option>
-		{% endfor %}
-	</select>
-
-	{# Radio of Checkbox #}
-	{% elseif type == 'checkbox' or type == 'radio' %}
-	{% set selected = value is iterable ? value : [value] %}
-	<div class="filter-options-wrapper" data-limit-options="{{ limit_options }}" data-expand-label="{{ option_list_expand_label }}" data-collapse-label="{{ option_list_collapse_label }}">
-		{% for key, val in options %}
-		<div class="form-check">
+        {# Radio of Checkbox #}
+        {% elseif type == 'checkbox' or type == 'radio' %}
+        {% if label and show_field_label %}
+        <label class="form-label">{{ label }}</label>
+        {% endif %}
+        {% set selected = value is iterable ? value : [value] %}
+        <div class="filter-options-wrapper" data-limit-options="{{ limit_options }}" data-expand-label="{{ option_list_expand_label }}" data-collapse-label="{{ option_list_collapse_label }}">
+                {% for key, val in options %}
+                <div class="form-check">
 			<label class="form-check-label">
 				<input class="form-check-input" type="{{ type }}" name="{{ name }}{% if type == 'checkbox' %}[]{% endif %}" value="{{ val }}" {% if val in selected %}checked{% endif %}>
                                 {{ key }}
@@ -89,12 +107,15 @@ Beschikbare presentatie-opties:
 		<button type="button" class="btn btn-sm btn-link filter-toggle-btn d-none" aria-expanded="false"></button>
 	</div>
 
-	{# Buttons #}
-	{% elseif type == 'buttons' %}
-	{% set layout = layout ?? 'horizontal' %}
-	{% set button_class = button_class ?? 'btn-outline-primary' %}
-	{% set all_label = all_label ?? 'Alles' %}
-	{% set show_all_button = show_all_button ?? true %}
+        {# Buttons #}
+        {% elseif type == 'buttons' %}
+        {% if label and show_field_label %}
+        <label class="form-label">{{ label }}</label>
+        {% endif %}
+        {% set layout = layout ?? 'horizontal' %}
+        {% set button_class = button_class ?? 'btn-outline-primary' %}
+        {% set all_label = all_label ?? 'Alles' %}
+        {% set show_all_button = show_all_button ?? true %}
 	
 	<div class="filter-buttons {{ layout == 'vertical'
 	? 'd-grid gap-2'
@@ -120,10 +141,16 @@ Beschikbare presentatie-opties:
 
         {# Single Date Field #}
         {% elseif type == 'date' %}
+        {% if label and show_field_label %}
+        <label class="form-label">{{ label }}</label>
+        {% endif %}
         <input type="text" class="form-control" name="{{ name }}" value="{{ value }}" data-date-picker data-date-format="{{ date_format }}">
 
         {# Date Range #}
         {% elseif type == 'date_range' %}
+        {% if label and show_field_label %}
+        <label class="form-label">{{ label }}</label>
+        {% endif %}
         <div class="d-flex gap-2 align-items-center mb-3">
                 <input type="text" class="form-control" name="from_{{ acf_field }}" value="{{ value.from ?? '' }}" data-date-range-start="{{ acf_field }}" data-date-format="{{ date_format }}">
                 <span class="text-muted">tot</span>
@@ -132,17 +159,20 @@ Beschikbare presentatie-opties:
 
         {# Range Slider #}
         {% elseif type == 'range' %}
+        {% if label and show_field_label %}
+        <label class="form-label">{{ label }}</label>
+        {% endif %}
         <div class="range-wrapper">
                 <div class="d-flex gap-2 align-items-center mb-3">
                         <input type="number" class="form-control" name="min_{{ acf_field }}" value="{{ value.min ?? options.min }}" min="{{ options.min }}" max="{{ options.max }}">
 
-			<span class="text-muted">tot</span>
+                        <span class="text-muted">tot</span>
 
-			<input type="number" class="form-control" name="max_{{ acf_field }}" value="{{ value.max ?? options.max }}" min="{{ options.min }}" max="{{ options.max }}">
-		</div>
+                        <input type="number" class="form-control" name="max_{{ acf_field }}" value="{{ value.max ?? options.max }}" min="{{ options.min }}" max="{{ options.max }}">
+                </div>
 
-		<div class="range-slider" data-slider data-min="{{ options.min }}" data-max="{{ options.max }}">
-		</div>
+                <div class="range-slider" data-slider data-min="{{ options.min }}" data-max="{{ options.max }}">
+                </div>
         </div>
 {% endif %}
 </div>

--- a/views/partials/list.twig
+++ b/views/partials/list.twig
@@ -1,18 +1,25 @@
 {% if posts|length %}
         <div class="row">
+                {% set forced_col = col_class|default('') %}
                 {% for item in posts %}
-                        <div class="{{ item.post_type == 'product' ? 'col-sm-6 col-lg-4 col-xxl-3' : 'col-12' }} fade-in-item visible">
-                                {# Probeer eerst tease-[post_type].twig, anders tease.twig #}
-                                {% include [
+                        {% set col = forced_col ?: (item.post_type == 'product' ? 'col-sm-6 col-lg-4 col-xxl-3' : 'col-12') %}
+                        <div class="{{ col }} fade-in-item visible">
+                                {# Gebruik een meegegeven tease-template, anders tease-[post_type].twig of standaard tease.twig #}
+                                {% set templates = [] %}
+                                {% if tease_template is defined %}
+                                        {% set templates = templates|merge([tease_template]) %}
+                                {% endif %}
+                                {% set templates = templates|merge([
                                         'partials/tease-' ~ item.post_type ~ '.twig',
                                         'partials/tease.twig'
-                                ] with { item: item } %}
+                                ]) %}
+                                {% include templates with { item: item } %}
                         </div>
                 {% endfor %}
         </div>
-	<div data-max-pages="{{ max_pages|e('html_attr') }}" hidden></div>
+        <div data-max-pages="{{ max_pages|e('html_attr') }}" hidden></div>
 {% else %}
-	<p>Geen resultaten gevonden.</p>
+        <p>Geen resultaten gevonden.</p>
 {% endif %}
 
 <div id="result-count" style="display: none;">{{ total }} resultaten gevonden</div>

--- a/views/partials/tease-search.twig
+++ b/views/partials/tease-search.twig
@@ -1,0 +1,20 @@
+<a href="{{ fn('get_permalink', item.ID) }}" class="search-tease d-flex align-items-center gap-3 py-2">
+    {% set thumb = get_thumbnail(item.ID) %}
+    {% if thumb %}
+        {{ image(thumb, {
+            figure_class: 'mb-0 flex-shrink-0',
+            img_class: 'rounded',
+            ratio: '1x1',
+            object_fit: 'cover',
+            lazyload: true,
+            width: 80,
+            height: 80
+        }) }}
+    {% else %}
+        <div class="flex-shrink-0 bg-light rounded" style="width:80px;height:80px;"></div>
+    {% endif %}
+    <div class="flex-grow-1">
+        <div class="text-muted small">{{ fn('get_post_type_object', item.post_type).labels.singular_name }}</div>
+        <h3 class="h5 mb-0">{{ item.post_title }}</h3>
+    </div>
+</a>

--- a/views/search.twig
+++ b/views/search.twig
@@ -1,13 +1,59 @@
-{# see `archive.twig` for an alternative strategy of extending templates #}
-{% extends "base.twig" %}
+{% extends "index.twig" %}
 
 {% block content %}
-  {# see `base.twig:27` for where this block's content will be inserted #}
-  <div class="content-wrapper">
-    {% for post in posts %}
-      {% include ['tease-'~post.post_type~'.twig', 'tease.twig'] %}
-    {% endfor %}
+<section class="bg-greylight">
+    <div class="container">
+        <form data-filter-form data-post-type="{{ post_type }}">
+            <input type="hidden" name="posts_per_page" value="{{ posts_per_page }}">
+            <input type="hidden" name="col_class" value="{{ col_class }}">
+            <input type="hidden" name="tease_template" value="partials/tease-search.twig">
+            {% for pt in allowed_post_types %}
+            <input type="hidden" name="post_types[]" value="{{ pt }}">
+            {% endfor %}
 
-    {% include 'partial/pagination.twig' with { pagination: posts.pagination({show_all: false, mid_size: 3, end_size: 2}) } %}
-  </div>
+            <div class="row mb-5">
+                <div class="col-md-4 d-flex align-items-center">
+                    <a href="{{ site.link }}">Home </a> / Zoek
+                </div>
+                <div class="col-md-8 d-flex align-items-center">
+                    {% if total is defined %}
+                    <p id="result-count" class="m-0" data-result-count>{{ total }} resultaten gevonden</p>
+                    {% endif %}
+                </div>
+            </div>
+
+            <div class="row mb-4">
+                <div class="col">
+                    <h4 class="m-0">{{ title }}</h4>
+                </div>
+            </div>
+
+            <input type="text" name="s" class="form-control mb-4" placeholder="Zoek op trefwoord..." value="{{ search_query|e }}">
+
+            {{ filter(filters.post_type, {
+                show_field_label: true,
+                layout: 'horizontal',
+                placeholder: 'Alle',
+                post_types: allowed_post_types
+            }) }}
+
+            <div class="position-relative">
+                <div id="filter-loader" data-filter-loader class="filter-overlay d-none">
+                    <div class="spinner-border text-secondary" role="status" aria-hidden="true"></div>
+                </div>
+                <div id="filter-results">
+                    {% set max_pages = max_num_pages %}
+                    {% include 'partials/list.twig' with { tease_template: 'partials/tease-search.twig', col_class: col_class } %}
+                </div>
+
+                {% if current_page < max_num_pages %}
+                <div class="text-center mt-4">
+                    <button type="button" class="btn btn-outline-dark" data-load-more>Laad meer</button>
+                </div>
+                {% endif %}
+            </div>
+        </form>
+    </div>
+</section>
 {% endblock %}
+


### PR DESCRIPTION
## Summary
- allow passing allowed post types and default to all search-enabled types
- support `post_type` source and horizontal layout for post type filter
- clean up AJAX filter counts for post type handling
- correctly serialize repeated `[]` inputs so post type filters persist
- introduce a dedicated search result teaser and let the list component accept an injected template
- allow overriding column classes so search results are always full width
- persist custom teaser and column class during AJAX filtering on the search page

## Testing
- `composer test` *(fails: Failed opening required '/workspace/skeletor/vendor/automattic/wordbless/src/../../../../wordpress//wp-settings.php')*


------
https://chatgpt.com/codex/tasks/task_e_68a02f2c72b88331865eaa90137e6e0d