### PR TITLE
Make search post types configurable

### DIFF
--- a/search.php
+++ b/search.php
@@ -14,13 +14,19 @@ $posts_per_page = 12;
 $context['posts_per_page'] = $posts_per_page;
 $context['col_class'] = 'col-12';
 
-$allowed_post_types = $_GET['post_types'] ?? [];
-if (!is_array($allowed_post_types)) {
-    $allowed_post_types = explode(',', $allowed_post_types);
-}
-$allowed_post_types = array_values(array_filter(array_map('sanitize_key', (array) $allowed_post_types)));
+// Post types that should be available in search results and filters.
+// Modify this array to control which post types are searchable.
+$allowed_post_types = [
+    'post',
+    'page',
+    // 'product',
+];
+
+$allowed_post_types = array_values(array_filter(array_map('sanitize_key', $allowed_post_types)));
 if (empty($allowed_post_types)) {
-    $allowed_post_types = array_values(get_post_types(['public' => true, 'exclude_from_search' => false], 'names'));
+    $allowed_post_types = array_values(
+        get_post_types(['public' => true, 'exclude_from_search' => false], 'names')
+    );
 }
 $context['allowed_post_types'] = $allowed_post_types;
 


### PR DESCRIPTION
## Summary
- allow configuring which post types are searchable

## Testing
- `composer test` *(fails: Failed opening required '/workspace/skeletor/vendor/automattic/wordbless/.../wordpress/wp-settings.php')*

------
https://chatgpt.com/codex/tasks/task_e_68a23e4a5db483318029d598d7b9232b