### PR TITLE
Ensure location filters keep 1-column layout

### DIFF
--- a/views/archive-locaties.twig
+++ b/views/archive-locaties.twig
@@ -8,6 +8,7 @@
 	<div class="container">
                <form data-filter-form data-post-type="{{ post_type }}">
                        <input type="hidden" name="posts_per_page" value="{{ posts_per_page }}">
+                       <input type="hidden" name="col_class" value="{{ col_class }}">
 			<div class="row mb-5">
 				<div class="col-md-4 d-flex align-items-center">
 					<a href="{{ site.link }}">Home </a> <span> / </span> {{ post_type|capitalize }}


### PR DESCRIPTION
## Summary
- keep locations archive in a single-column layout after filtering by passing `col_class` through the filter form

## Testing
- `composer test` *(fails: missing WordPress test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68a2d3af0ea0833183a45ce7365bbf71