### PR TITLE
Enhance accessibility for WCAG 2.0

### DIFF
--- a/views/base.twig
+++ b/views/base.twig
@@ -14,7 +14,7 @@
 			{% include 'header.twig' %}
 		{% endblock %}
 		
-		<main role="main" class="content-wrapper">
+<main id="content" role="main" class="content-wrapper" tabindex="-1">
 			{% if title %}<h1 class="d-none">{{title}}</h1>{% endif %}
 			{% block content %}
 				Sorry, no content

--- a/views/footer.twig
+++ b/views/footer.twig
@@ -18,12 +18,14 @@
 	<div class="footer bg-dark">
 		<div class="container">
 			<div class="row mb-5">
-				<div class="col-6 col-md-3 offset-md-2 offset-lg-3 mb-4 mb-md-0">
-					{{ heading(options.footer_navigatie_menu_titel, {
-						level: 'h5'
-					}) }}
-					{% include "partials/menu-clean.twig" with {'items': footermenu.get_items} %}
-				</div>
+                                <div class="col-6 col-md-3 offset-md-2 offset-lg-3 mb-4 mb-md-0">
+                                        {{ heading(options.footer_navigatie_menu_titel, {
+                                                level: 'h5'
+                                        }) }}
+                                        <nav aria-label="Footer navigation">
+                                                {% include "partials/menu-clean.twig" with {'items': footermenu.get_items} %}
+                                        </nav>
+                                </div>
 				<div class="col-6 col-md-3 col-lg-2 mb-4 mb-md-0">
 					{{ heading(options.footer_navigatie_socialmedia_titel, {
 						level: 'h5'
@@ -39,10 +41,10 @@
 					}) }}
 				</div>
 				
-				<div class="col-md-4 order-md-first text-center text-md-start">
-					<img height="30" src="{{ theme.link }}/assets/images/emonks-color.svg" alt="{{ site.title }}" class="mb-3">
-					{{ text(options.footer_navigatie_tekst) }}
-				</div>
+                                <div class="col-md-4 order-md-first text-center text-md-start">
+                                        <img height="30" src="{{ theme.link }}/assets/images/emonks-color.svg" alt="{{ site.name }}" class="mb-3">
+                                        {{ text(options.footer_navigatie_tekst) }}
+                                </div>
 			</div>
 			<div class="subfooter text-center text-md-start">
 				<div class="">©{{"now"|date('Y')}} All rights reserved {{ site.title}} </div>

--- a/views/header.twig
+++ b/views/header.twig
@@ -7,7 +7,9 @@
                         </div>
                         {% if servicemenu %}
                                 <div class="col-auto d-flex align-items-center">
-                                        {% include "partials/menu-horizontal.twig" with {'items': servicemenu.get_items} %}
+                                        <nav aria-label="Service navigation">
+                                                {% include "partials/menu-horizontal.twig" with {'items': servicemenu.get_items} %}
+                                        </nav>
                                 </div>
                         {% endif %}
                 </div>
@@ -15,18 +17,20 @@
 </div>
 {% endif %}
 
-<header class="header d-flex align-items-center">
+<header class="header d-flex align-items-center" role="banner">
         <div class="container">
                 <div class="row w-100 g-2">
                         <div class="col d-flex align-items-center">
                                 <a class="header-brand" href="{{ site.url }}" rel="home">
                                         <span class="d-none">{{ site.name }}</span>
-                                        <img height="30" src="{{ theme.link }}/assets/images/emonks-color.svg" alt="{{ site.title }}">
+                                        <img height="30" src="{{ theme.link }}/assets/images/emonks-color.svg" alt="{{ site.name }}">
                                 </a>
                         </div>
                         {% if headermenu %}
                                 <div class="col-auto d-none d-lg-flex align-items-center">
-                                        {% include "partials/menu-dropdown.twig" with {'items': headermenu.get_items} %}
+                                        <nav class="primary-navigation" aria-label="Primary navigation">
+                                                {% include "partials/menu-dropdown.twig" with {'items': headermenu.get_items} %}
+                                        </nav>
                                 </div>
                         {% endif %}
                 </div>
@@ -35,16 +39,16 @@
 
 {% if headermenu %}
         <!-- Hamburger menu button -->
-        <button id="mobilemenubtn" class="d-lg-none">
-                <div class="lines">
+        <button id="mobilemenubtn" class="d-lg-none" aria-label="Toggle navigation" aria-controls="mobilemenu" aria-expanded="false">
+                <span class="lines" aria-hidden="true">
                         <span></span>
                         <span></span>
                         <span></span>
-                </div>
+                </span>
         </button>
 
         <!-- Mobile menu -->
-        <nav class="mobilemenu" id="mobilemenu">
+        <nav class="mobilemenu" id="mobilemenu" aria-label="Mobile navigation">
                 <ul class="menu-items">
                         {% include "partials/menu.twig" with {'items': mobielmenu.get_items} %}
                 </ul>

--- a/views/partials/menu-clean.twig
+++ b/views/partials/menu-clean.twig
@@ -2,10 +2,11 @@
 	{% for item in items %}
 		<li class="nav-item {% if item.children|length > 0 %}dropdown{% endif %} {{ item.classes | join(' ') }} d-flex align-items-center">
 			<a 
-				class="{% if item.children|length > 0 %}dropdown-toggle{% endif %}" 
-				href="{{ item.link }}" 
-				{% if item.target %}target="{{ item.target }}"{% endif %}
-				{% if item.children|length > 0 %}data-bs-toggle="dropdown"  aria-expanded="false"{% endif %}
+                                class="{% if item.children|length > 0 %}dropdown-toggle{% endif %}"
+                                href="{{ item.link }}"
+                                {% if item.current %}aria-current="page"{% endif %}
+                                {% if item.target %}target="{{ item.target }}"{% endif %}
+                                {% if item.children|length > 0 %}data-bs-toggle="dropdown"  aria-expanded="false"{% endif %}
 			>
 				{{ item.title }}
 			</a>

--- a/views/partials/menu-dropdown.twig
+++ b/views/partials/menu-dropdown.twig
@@ -10,9 +10,10 @@
 		<li class="nav-item {% if item.children|length > 0 %}dropdown position-static{% endif %} {{ item.classes | join(' ') }} d-flex align-items-center">
 			<a 
 				class="{{ linkstijl }} {% if item.children|length > 0 %}dropdown-toggle{% endif %}" 
-				href="{{ item.link }}" 
-				{% if item.target %}target="{{ item.target }}"{% endif %}
-				{% if item.children|length > 0 %}data-bs-toggle="dropdown" aria-expanded="false"{% endif %}
+                                href="{{ item.link }}"
+                                {% if item.current %}aria-current="page"{% endif %}
+                                {% if item.target %}target="{{ item.target }}"{% endif %}
+                                {% if item.children|length > 0 %}data-bs-toggle="dropdown" aria-expanded="false"{% endif %}
 			>
 				{{ item.title }}
 			</a>

--- a/views/partials/menu-horizontal.twig
+++ b/views/partials/menu-horizontal.twig
@@ -2,10 +2,11 @@
 	{% for item in items %}
 		<li class="nav-item {% if item.children|length > 0 %}dropdown{% endif %} {{ item.classes | join(' ') }} d-flex align-items-center">
 			<a 
-				class="{% if item.children|length > 0 %}dropdown-toggle{% endif %}" 
-				href="{{ item.link }}" 
-				{% if item.target %}target="{{ item.target }}"{% endif %}
-				{% if item.children|length > 0 %}data-bs-toggle="dropdown"  aria-expanded="false"{% endif %}
+                                class="{% if item.children|length > 0 %}dropdown-toggle{% endif %}"
+                                href="{{ item.link }}"
+                                {% if item.current %}aria-current="page"{% endif %}
+                                {% if item.target %}target="{{ item.target }}"{% endif %}
+                                {% if item.children|length > 0 %}data-bs-toggle="dropdown"  aria-expanded="false"{% endif %}
 			>
 				{{ item.title }}
 			</a>

--- a/views/partials/menu.twig
+++ b/views/partials/menu.twig
@@ -10,9 +10,10 @@
 		<li class="nav-item {% if item.children|length > 0 %}dropdown{% endif %} {{ item.classes | join(' ') }} d-flex align-items-center">
 			<a 
 				class="{{ linkstijl }} {% if item.children|length > 0 %}dropdown-toggle{% endif %}" 
-				href="{{ item.link }}" 
-				{% if item.target %}target="{{ item.target }}"{% endif %}
-				{% if item.children|length > 0 %}data-bs-toggle="dropdown"  aria-expanded="false"{% endif %}
+                                href="{{ item.link }}"
+                                {% if item.current %}aria-current="page"{% endif %}
+                                {% if item.target %}target="{{ item.target }}"{% endif %}
+                                {% if item.children|length > 0 %}data-bs-toggle="dropdown"  aria-expanded="false"{% endif %}
 			>
 				{{ item.title }}
 			</a>


### PR DESCRIPTION
## Summary
- Add skip-link target and tabindex to main content
- Introduce ARIA labels and banner role for header and navigation menus
- Provide `aria-current` attributes and improved alt text for navigation items

## Testing
- `composer test` *(fails: Failed opening required '.../wordpress//wp-settings.php')*

------
https://chatgpt.com/codex/tasks/task_e_68a300da4a748331b0fa9298fe24e19c