### PR TITLE
feat: allow Icon component to be used as a link with positioned text

### DIFF
--- a/components/library/icon/Icon.php
+++ b/components/library/icon/Icon.php
@@ -25,7 +25,10 @@ class Components_Icon extends Site {
             'library' => 'fontawesome',
             'class' => '',
             'container_height' => 20,
-            'container_width' => 20
+            'container_width' => 20,
+            'title' => '',
+            'url' => '',
+            'position' => 'right'
         ];
 
         $settings = array_merge($defaults, $args);
@@ -62,11 +65,19 @@ class Components_Icon extends Site {
             $container_width .= 'px';
         }
 
+        $title = sanitize_text_field($settings['title']);
+        $url = esc_url($settings['url']);
+        $allowed_positions = ['left', 'right', 'top', 'bottom'];
+        $position = in_array($settings['position'], $allowed_positions, true) ? $settings['position'] : 'right';
+
         $context = [
             'svg' => $svg,
-            'class' => trim('icon ' . $settings['class']),
+            'class' => trim($settings['class']),
             'container_width' => $container_width,
-            'container_height' => $container_height
+            'container_height' => $container_height,
+            'title' => $title,
+            'url' => $url,
+            'position' => $position
         ];
 
         return Timber::compile('icon/icon.twig', $context);

--- a/components/library/icon/_icon.scss
+++ b/components/library/icon/_icon.scss
@@ -3,6 +3,49 @@
     align-items: center;
     justify-content: center;
     line-height: 1;
+    text-align: center;
+}
+
+.icon__figure {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.icon__text {
+    display: inline-block;
+}
+
+.icon--left {
+    flex-direction: row;
+}
+
+.icon--right {
+    flex-direction: row-reverse;
+}
+
+.icon--top {
+    flex-direction: column;
+}
+
+.icon--bottom {
+    flex-direction: column-reverse;
+}
+
+.icon--left .icon__text {
+    margin-right: 0.5em;
+}
+
+.icon--right .icon__text {
+    margin-left: 0.5em;
+}
+
+.icon--top .icon__text {
+    margin-bottom: 0.5em;
+}
+
+.icon--bottom .icon__text {
+    margin-top: 0.5em;
 }
 
 .icon svg {

--- a/components/library/icon/icon.twig
+++ b/components/library/icon/icon.twig
@@ -2,13 +2,16 @@
 Icon Component
 
 Usage:
-{{ icon({ 
-    icon: 'arrow-down', 
-    style: 'light', 
-    library: 'fontawesome', 
+{{ icon({
+    icon: 'arrow-down',
+    style: 'light',
+    library: 'fontawesome',
     class: 'arrow',
-    container_height: 20, 
-    container_width: 20 
+    container_height: 20,
+    container_width: 20,
+    title: 'More',
+    url: 'https://example.com',
+    position: 'right'
 }) }}
 
 Parameters:
@@ -18,8 +21,19 @@ Parameters:
 - container_height (int|string, optional): Hoogte van de container. Standaard 30.
 - container_width (int|string, optional): Breedte van de container. Standaard gelijk aan de hoogte.
 - class (string, optional): Extra CSS-klassen voor de container.
+- title (string, optional): Tekst bij het icoon.
+- url (string, optional): Link om het icoon heen. Leeg laat alleen het icoon zien.
+- position (string, optional): Positie van de tekst: 'left', 'right', 'top' of 'bottom'. Standaard 'right'.
 #}
-
-<span class="{{ class }}"{% if container_width != 'auto' or container_height != 'auto' %} style="{% if container_width != 'auto' %}width: {{ container_width }};{% endif %}{% if container_height != 'auto' %} height: {{ container_height }};{% endif %}"{% endif %}>
-    {{ svg|raw }}
-</span>
+{% set tag = url ? 'a' : 'span' %}
+<{{ tag }} class="icon icon--{{ position }} {{ class }}"{% if url %} href="{{ url }}"{% endif %}>
+    {% if position in ['left','top'] and title %}
+        <span class="icon__text">{{ title }}</span>
+    {% endif %}
+    <span class="icon__figure"{% if container_width != 'auto' or container_height != 'auto' %} style="{% if container_width != 'auto' %}width: {{ container_width }};{% endif %}{% if container_height != 'auto' %} height: {{ container_height }};{% endif %}"{% endif %}>
+        {{ svg|raw }}
+    </span>
+    {% if position in ['right','bottom'] and title %}
+        <span class="icon__text">{{ title }}</span>
+    {% endif %}
+</{{ tag }}>


### PR DESCRIPTION
## Summary
- add `title`, `url`, and `position` options to Icon component
- support rendering optional text around an icon and wrap in a link when a URL is provided
- style new icon/text layouts

## Testing
- `vendor/bin/phpunit` *(fails: Failed opening required '/workspace/skeletor/vendor/automattic/wordbless/src/../../../../wordpress//wp-settings.php')*


------
https://chatgpt.com/codex/tasks/task_e_68a460c45e288331a5da7d1c681ccc0d