### PR TITLE
feat: allow Icon component to be used as a link with positioned text

### DIFF
--- a/components/library/icon/Icon.php
+++ b/components/library/icon/Icon.php
@@ -25,7 +25,17 @@ class Components_Icon extends Site {
             'library' => 'fontawesome',
             'class' => '',
             'container_height' => 20,
-            'container_width' => 20
+            'container_width' => 20,
+            'title' => '',
+            'url' => '',
+            'title_position' => 'right',
+            'title_level' => 'span',
+            'title_class' => '',
+            'icon_class' => '',
+            'gap' => 10,
+            'target' => 'self',
+            'color_primary' => '',
+            'color_secondary' => ''
         ];
 
         $settings = array_merge($defaults, $args);
@@ -48,7 +58,19 @@ class Components_Icon extends Site {
 
         // Remove existing width and height attributes and force 100% scaling
         $svg = preg_replace('/\s(width|height)="[^"]*"/', '', $svg);
-        $svg = preg_replace('/<svg\b([^>]*)>/', '<svg$1 width="100%" height="100%">', $svg, 1);
+        $icon_class = trim($settings['icon_class']);
+        $color_primary = sanitize_text_field($settings['color_primary']);
+        $color_secondary = sanitize_text_field($settings['color_secondary']);
+        $style_attr = '';
+        if ($color_primary !== '') {
+            $style_attr .= '--fa-primary-color:' . $color_primary . ';';
+        }
+        if ($color_secondary !== '') {
+            $style_attr .= '--fa-secondary-color:' . $color_secondary . ';';
+        }
+        $class_attr = $icon_class !== '' ? ' class="' . esc_attr($icon_class) . '"' : '';
+        $style_attr = $style_attr !== '' ? ' style="' . esc_attr($style_attr) . '"' : '';
+        $svg = preg_replace('/<svg\b([^>]*)>/', '<svg$1' . $class_attr . $style_attr . ' width="100%" height="100%">', $svg, 1);
 
         $container_height = $settings['container_height'];
         if (is_numeric($container_height)) {
@@ -62,11 +84,36 @@ class Components_Icon extends Site {
             $container_width .= 'px';
         }
 
+        $gap = $settings['gap'];
+        if (is_numeric($gap)) {
+            $gap .= 'px';
+        } else {
+            $gap = sanitize_text_field($gap);
+        }
+
+        $allowed_targets = ['self', 'blank'];
+        $target = in_array($settings['target'], $allowed_targets, true) ? '_' . $settings['target'] : '_self';
+
+        $title = sanitize_text_field($settings['title']);
+        $url = esc_url($settings['url']);
+        $allowed_positions = ['left', 'right', 'top', 'bottom'];
+        $title_position = in_array($settings['title_position'], $allowed_positions, true) ? $settings['title_position'] : 'right';
+        $allowed_levels = ['span', 'p', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6'];
+        $title_level = in_array($settings['title_level'], $allowed_levels, true) ? $settings['title_level'] : 'span';
+        $title_class = sanitize_text_field($settings['title_class']);
+
         $context = [
             'svg' => $svg,
-            'class' => trim('icon ' . $settings['class']),
+            'class' => trim($settings['class']),
             'container_width' => $container_width,
-            'container_height' => $container_height
+            'container_height' => $container_height,
+            'title' => $title,
+            'url' => $url,
+            'title_position' => $title_position,
+            'title_level' => $title_level,
+            'title_class' => $title_class,
+            'gap' => $gap,
+            'target' => $target
         ];
 
         return Timber::compile('icon/icon.twig', $context);

--- a/components/library/icon/_icon.scss
+++ b/components/library/icon/_icon.scss
@@ -3,6 +3,34 @@
     align-items: center;
     justify-content: center;
     line-height: 1;
+    text-align: center;
+    gap: 10px;
+}
+
+.icon__figure {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.icon__text {
+    display: inline-block;
+}
+
+.icon--left {
+    flex-direction: row;
+}
+
+.icon--right {
+    flex-direction: row-reverse;
+}
+
+.icon--top {
+    flex-direction: column;
+}
+
+.icon--bottom {
+    flex-direction: column-reverse;
 }
 
 .icon svg {

--- a/components/library/icon/icon.twig
+++ b/components/library/icon/icon.twig
@@ -2,13 +2,23 @@
 Icon Component
 
 Usage:
-{{ icon({ 
-    icon: 'arrow-down', 
-    style: 'light', 
-    library: 'fontawesome', 
+{{ icon({
+    icon: 'arrow-down',
+    style: 'light',
+    library: 'fontawesome',
     class: 'arrow',
-    container_height: 20, 
-    container_width: 20 
+    container_height: 20,
+    container_width: 20,
+    title: 'More',
+    url: 'https://example.com',
+    title_position: 'right',
+    title_level: 'span',
+    title_class: '',
+    icon_class: '',
+    gap: 10,
+    target: 'blank',
+    color_primary: '',
+    color_secondary: ''
 }) }}
 
 Parameters:
@@ -18,8 +28,27 @@ Parameters:
 - container_height (int|string, optional): Hoogte van de container. Standaard 30.
 - container_width (int|string, optional): Breedte van de container. Standaard gelijk aan de hoogte.
 - class (string, optional): Extra CSS-klassen voor de container.
+- title (string, optional): Tekst bij het icoon.
+- url (string, optional): Link om het icoon heen. Leeg laat alleen het icoon zien.
+- title_position (string, optional): Positie van de tekst: 'left', 'right', 'top' of 'bottom'. Standaard 'right'.
+- title_level (string, optional): HTML-tag voor de titel, zoals 'span', 'h2', 'h3'. Standaard 'span'.
+- title_class (string, optional): Extra CSS-klassen voor de titel.
+- icon_class (string, optional): Extra CSS-klassen voor het SVG-element.
+- gap (int|string, optional): Ruimte tussen icoon en titel. Standaard 10.
+- target (string, optional): Linkdoel, 'self' of 'blank'. Standaard 'self'.
+- color_primary (string, optional): Kleur voor het primaire deel van een duotone icoon.
+- color_secondary (string, optional): Kleur voor het secundaire deel van een duotone icoon.
 #}
-
-<span class="{{ class }}"{% if container_width != 'auto' or container_height != 'auto' %} style="{% if container_width != 'auto' %}width: {{ container_width }};{% endif %}{% if container_height != 'auto' %} height: {{ container_height }};{% endif %}"{% endif %}>
-    {{ svg|raw }}
-</span>
+{% set tag = url ? 'a' : 'span' %}
+{% set text_tag = title_level %}
+<{{ tag }} class="icon icon--{{ title_position }} {{ class }}" style="gap: {{ gap }};"{% if url %} href="{{ url }}" target="{{ target }}"{% endif %}>
+    {% if title_position in ['left','top'] and title %}
+        <{{ text_tag }} class="icon__text {{ title_class }}">{{ title }}</{{ text_tag }}>
+    {% endif %}
+    <span class="icon__figure"{% if container_width != 'auto' or container_height != 'auto' %} style="{% if container_width != 'auto' %}width: {{ container_width }};{% endif %}{% if container_height != 'auto' %} height: {{ container_height }};{% endif %}"{% endif %}>
+        {{ svg|raw }}
+    </span>
+    {% if title_position in ['right','bottom'] and title %}
+        <{{ text_tag }} class="icon__text {{ title_class }}">{{ title }}</{{ text_tag }}>
+    {% endif %}
+</{{ tag }}>


### PR DESCRIPTION
## Summary
- add optional `gap` and `target` parameters to Icon component
- render target attribute and style-based spacing for icon text
- switch styling to flex `gap` and remove orientation-specific margins
- rename `position` to `title_position` and support custom `title_level` and `title_class`
- allow extra `icon_class` and duotone `color_primary`/`color_secondary`

## Testing
- `vendor/bin/phpunit` *(fails: Failed opening required '/workspace/skeletor/vendor/automattic/wordbless/src/../../../../wordpress//wp-settings.php')*


------
https://chatgpt.com/codex/tasks/task_e_68a460c45e288331a5da7d1c681ccc0d