### PR TITLE
feat(filter): rename acf source and add user/author

### DIFF
--- a/README.html
+++ b/README.html
@@ -82,6 +82,8 @@
 <li><code>sort_select</code> accepteert <code>id</code>, <code>name</code>, <code>label</code>, <code>value</code> en voegt een standaard sorteermenu toe.</li>
 </ul>
 
+<p>Mogelijke waardes voor <code>source</code> zijn <code>field</code>, <code>meta</code>, <code>taxonomy</code>, <code>post_date</code>, <code>post_type</code>, <code>user</code> en <code>author</code>.</p>
+
 <h3 id="heading">Heading</h3>
 
 <pre><code class="twig">{{ heading(item.titel, {

--- a/README.md
+++ b/README.md
@@ -61,15 +61,17 @@ Definieer filters in PHP en render ze in Twig:
 - `sort_select` accepteert `id`, `name`, `label`, `value` en voegt een standaard sorteermenu toe.
 - Voor type `buttons` zijn extra opties beschikbaar: `button_class`, `all_label`, `show_all_button`.
 
-Voor een datumfilter kan gefilterd worden op publicatiedatum (`source: 'post_date'`) of op een ACF-datumveld (`source: 'acf'`).
+Mogelijke waardes voor `source` zijn `field`, `meta`, `taxonomy`, `post_date`, `post_type`, `user` en `author`.
+
+Voor een datumfilter kan gefilterd worden op publicatiedatum (`source: 'post_date'`) of op een veld (`source: 'field'`).
 
 ```php
-// Enkel datumveld (ACF)
+// Enkel datumveld (field)
 $context['filters']['event_date'] = [
   'name'   => 'event_date',
   'label'  => 'Datum',
   'type'   => 'date',
-  'source' => 'acf',
+  'source' => 'field',
 ];
 
 // Van/tot op publicatiedatum

--- a/archive.php
+++ b/archive.php
@@ -33,7 +33,7 @@ $context['col_class'] = 'col-12 mb-4';
  *   'name'       => 'uren',                   // input name, ook gebruikt in GET
  *   'label'      => 'Uren',                   // veldlabel
  *   'type'       => 'checkbox',               // 'select', 'checkbox', 'radio', 'range'
- *   'source'     => 'acf',                    // 'acf' of 'taxonomy'
+ *   'source'     => 'field',                  // 'field' of 'taxonomy'
  *   'value'      => $_GET['uren'] ?? null,    // huidige waarde (optioneel)
  *   'options'    => Components_Filter::get_options_from_meta('uren'), // array met key => value
  *
@@ -56,7 +56,7 @@ $context['filters']['rating'] = [
   'name'   => 'rating',
   'label'  => 'Rating',
   'type'   => 'range',
-  'source' => 'acf'
+  'source' => 'field'
 ];
 
 // 🧩 Filter: publicatiedatum (van–tot)

--- a/components/library/filter/FilterAjax.php
+++ b/components/library/filter/FilterAjax.php
@@ -70,7 +70,7 @@ class Components_FilterAjax {
                // ✏️ Vul de huidige waardes in en sla standaardwaarden over
                foreach ($filter_definitions as $fname => &$def) {
                        $type   = $def['type'] ?? 'select';
-                       $source = $def['source'] ?? 'acf';
+                       $source = $def['source'] ?? 'field';
                        $name   = $def['name'] ?? $fname;
 
                        if ($type === 'range') {
@@ -235,7 +235,7 @@ class Components_FilterAjax {
 
                foreach ($filter_defs_for_counts as $fname => &$def) {
                        $ftype = $def['type'] ?? 'select';
-                       $fsrc  = $def['source'] ?? 'meta';
+                       $fsrc  = $def['source'] ?? 'field';
                        $key   = $def['name'] ?? $fname;
 
                        if ($fsrc === 'post_type') {
@@ -264,10 +264,14 @@ class Components_FilterAjax {
                        }
 
                        if (empty($def['options'])) {
-                               if ($fsrc === 'acf' || $fsrc === 'meta') {
+                               if ($fsrc === 'field' || $fsrc === 'meta') {
                                        $def['options'] = Components_Filter::get_options_from_meta($key);
                                } elseif ($fsrc === 'taxonomy') {
                                        $def['options'] = Components_Filter::get_options_from_taxonomy($key);
+                               } elseif ($fsrc === 'user') {
+                                       $def['options'] = Components_Filter::get_user_options();
+                               } elseif ($fsrc === 'author') {
+                                       $def['options'] = Components_Filter::get_author_options($query_post_type);
                                }
                        }
                }


### PR DESCRIPTION
## Summary
- replace `acf` source with `field` and allow `user` and `author`
- document new sources in README and sample archive

## Testing
- `composer test` *(fails: Failed opening required '/workspace/skeletor/vendor/automattic/wordbless/src/../../../../wordpress//wp-settings.php')*

------
https://chatgpt.com/codex/tasks/task_e_68a57c157700833194532fd30595d6ff