### PR TITLE
Improve mobile menu with service links and breakpoint controls

### DIFF
--- a/assets/js/scripts/mobilemenu.js
+++ b/assets/js/scripts/mobilemenu.js
@@ -1,17 +1,38 @@
 export function mobileMenu() {
-	const mobileMenuBtn = document.getElementById('mobilemenubtn');
-	const mobileMenu = document.getElementById('mobilemenu');
+        const mobileMenuBtn = document.getElementById('mobilemenubtn');
+        const mobileMenu = document.getElementById('mobilemenu');
+        const breakpoint = parseInt(getComputedStyle(document.documentElement).getPropertyValue('--mobile-menu-breakpoint')) || 992;
 
-	mobileMenuBtn.addEventListener('click', () => {
-		mobileMenuBtn.classList.toggle('active');
-		mobileMenu.classList.toggle('active');
-	});
+        mobileMenuBtn.addEventListener('click', () => {
+                const isOpen = mobileMenuBtn.classList.toggle('active');
+                mobileMenu.classList.toggle('active', isOpen);
+                mobileMenuBtn.setAttribute('aria-expanded', isOpen);
+        });
 
-	// Optioneel: Sluiten bij klikken buiten het menu
-	document.addEventListener('click', (e) => {
-		if (!mobileMenu.contains(e.target) && !mobileMenuBtn.contains(e.target)) {
-			mobileMenuBtn.classList.remove('active');
-			mobileMenu.classList.remove('active');
-		}
-	});
+        // Sluiten bij klikken buiten het menu
+        document.addEventListener('click', (e) => {
+                if (!mobileMenu.contains(e.target) && !mobileMenuBtn.contains(e.target)) {
+                        mobileMenuBtn.classList.remove('active');
+                        mobileMenu.classList.remove('active');
+                        mobileMenuBtn.setAttribute('aria-expanded', 'false');
+                }
+        });
+
+        // Sluiten bij venstergrootte voorbij het breekpunt
+        window.addEventListener('resize', () => {
+                if (window.innerWidth >= breakpoint) {
+                        mobileMenuBtn.classList.remove('active');
+                        mobileMenu.classList.remove('active');
+                        mobileMenuBtn.setAttribute('aria-expanded', 'false');
+                }
+        });
+
+        // Sluiten met Escape-toets
+        document.addEventListener('keydown', (e) => {
+                if (e.key === 'Escape') {
+                        mobileMenuBtn.classList.remove('active');
+                        mobileMenu.classList.remove('active');
+                        mobileMenuBtn.setAttribute('aria-expanded', 'false');
+                }
+        });
 }

--- a/assets/scss/layout/_mobilemenu.scss
+++ b/assets/scss/layout/_mobilemenu.scss
@@ -1,3 +1,24 @@
+// Breakpoint for mobile menu
+$mobile-menu-breakpoint: 992px !default;
+
+:root {
+        --mobile-menu-breakpoint: #{$mobile-menu-breakpoint};
+}
+
+.mobile-only {
+        @media (min-width: $mobile-menu-breakpoint) {
+                display: none !important;
+        }
+}
+
+.desktop-only {
+        display: none !important;
+
+        @media (min-width: $mobile-menu-breakpoint) {
+                display: flex !important;
+        }
+}
+
 /* Hamburger button styles */
 #mobilemenubtn {
 	position: fixed;
@@ -42,45 +63,56 @@
 
 /* Fullscreen menu styles */
 .mobilemenu {
-	position: fixed;
-	top: 0;
-	left: 0;
-	width: 100vw;
-	height: 100vh;
-	background-color: rgba($light, 0.95); 
-	z-index: 999;
-	transform: translateX(-100%);
-	transition: transform 0.5s $ease;
-	display: flex;
-	flex-direction: column;
-	justify-content: center;
-	align-items: center;
+        position: fixed;
+        top: 0;
+        left: 0;
+        width: 100vw;
+        height: 100vh;
+        background-color: rgba($light, 0.95);
+        z-index: 999;
+        transform: translateX(-100%);
+        opacity: 0;
+        transition: transform 0.5s $ease, opacity 0.5s $ease;
+        display: flex;
+        flex-direction: column;
+        justify-content: center;
+        align-items: center;
 
-	&.active {
-		transform: translateX(0);
-	}
+        &.active {
+                transform: translateX(0);
+                opacity: 1;
+        }
 
-	.menu-items {
-		list-style: none;
-		padding: 0;
-		margin: 0;
-		li {
-			margin: 10px 0;
-			justify-content: center !important;
-			a:not(.btn) {
-				color: $dark; 
-				text-decoration: none;
-				transition: color 0.3s $ease;
-				@extend .h4;
-				margin: 0;
-				&:hover {
-					color: $primary; 
-				}
-			}
-		}
-	}
+        .menu-items {
+                list-style: none;
+                padding: 0;
+                margin: 0;
+                li {
+                        margin: 10px 0;
+                        justify-content: center !important;
+                        a:not(.btn) {
+                                color: $dark;
+                                text-decoration: none;
+                                transition: color 0.3s $ease;
+                                @extend .h4;
+                                margin: 0;
+                                &:hover {
+                                        color: $primary;
+                                }
+                        }
+                }
+        }
+
+        .service-menu {
+                margin-top: 20px;
+                padding-top: 10px;
+                border-top: 1px solid rgba($dark, .1);
+        }
 }
 
-@include media-breakpoint-up(md) {
-
+@media (min-width: $mobile-menu-breakpoint) {
+        #mobilemenubtn,
+        .mobilemenu {
+                display: none !important;
+        }
 }

--- a/views/header.twig
+++ b/views/header.twig
@@ -1,5 +1,5 @@
 {% if show_topbar %}
-<div class="topbar d-none d-lg-flex align-items-center">
+<div class="topbar desktop-only align-items-center">
 	<div class="container">
 		<div class="row w-100 g-2">
 			<div class="col small d-flex align-items-center">
@@ -26,31 +26,36 @@
 					<img height="30" src="{{ theme.link }}/assets/images/emonks-color.svg" alt="{{ site.name }}">
 				</a>
 			</div>
-			{% if headermenu %}
-			<div class="col-auto d-none d-lg-flex align-items-center">
-				<nav class="primary-navigation" aria-label="Primary navigation">
-					{% include "partials/menu-dropdown.twig" with {'items': headermenu.get_items} %}
-				</nav>
-			</div>
-			{% endif %}
+                        {% if headermenu %}
+                        <div class="col-auto desktop-only align-items-center">
+                                <nav class="primary-navigation" aria-label="Primary navigation">
+                                        {% include "partials/menu-dropdown.twig" with {'items': headermenu.get_items} %}
+                                </nav>
+                        </div>
+                        {% endif %}
 		</div>
 	</div>
 </header>
 
 {% if headermenu %}
 <!-- Hamburger menu button -->
-<button id="mobilemenubtn" class="d-lg-none" aria-label="Toggle navigation" aria-controls="mobilemenu" aria-expanded="false">
-	<span class="lines" aria-hidden="true">
-		<span></span>
-		<span></span>
-		<span></span>
-	</span>
+<button id="mobilemenubtn" class="mobile-only" aria-label="Toggle navigation" aria-controls="mobilemenu" aria-expanded="false">
+        <span class="lines" aria-hidden="true">
+                <span></span>
+                <span></span>
+                <span></span>
+        </span>
 </button>
 
 <!-- Mobile menu -->
-<nav class="mobilemenu" id="mobilemenu" aria-label="Mobile navigation">
-	<ul class="menu-items">
-		{% include "partials/menu.twig" with {'items': mobielmenu.get_items} %}
-	</ul>
+<nav class="mobilemenu mobile-only" id="mobilemenu" aria-label="Mobile navigation">
+        <ul class="menu-items">
+                {% include "partials/menu.twig" with {'items': mobielmenu.get_items} %}
+        </ul>
+        {% if servicemenu %}
+        <ul class="menu-items service-menu">
+                {% include "partials/menu.twig" with {'items': servicemenu.get_items} %}
+        </ul>
+        {% endif %}
 </nav>
 {% endif %}


### PR DESCRIPTION
## Summary
- add service menu to mobile navigation
- allow configurable breakpoint and add open/close animations
- auto collapse mobile menu past breakpoint and on outside click

## Testing
- `composer test` *(fails: Failed opening required '/workspace/skeletor/vendor/automattic/wordbless/.../wp-settings.php')*

------
https://chatgpt.com/codex/tasks/task_e_68a724e49c10833186b2250f6d1c8b73